### PR TITLE
fix(tables): restore homogeneous rows and progressive column disclosure

### DIFF
--- a/src/components/browse/browse-table.tsx
+++ b/src/components/browse/browse-table.tsx
@@ -1,26 +1,32 @@
 import type { ReactNode } from "react"
 
+export type BrowseTableHeader = string | { label: string; className?: string }
+
 export function BrowseTable({
   headers,
   children,
 }: {
-  headers: string[]
+  headers: BrowseTableHeader[]
   children: ReactNode
 }) {
   return (
     <div className="overflow-hidden rounded-2xl border">
       <div className="overflow-x-auto">
-        <table className="w-full text-sm md:text-base">
+        <table className="w-full text-sm">
           <thead>
             <tr className="border-b bg-muted/50">
-              {headers.map((header, i) => (
-                <th
-                  key={header}
-                  className={`px-3 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground whitespace-nowrap first:pl-6 last:pr-6 ${i === 0 ? "text-left w-[40%]" : "text-center"}`}
-                >
-                  {header}
-                </th>
-              ))}
+              {headers.map((header, i) => {
+                const label = typeof header === "string" ? header : header.label
+                const extra = typeof header === "string" ? "" : (header.className ?? "")
+                return (
+                  <th
+                    key={label}
+                    className={`px-3 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground whitespace-nowrap first:pl-6 last:pr-6 ${i === 0 ? "text-left w-[40%]" : "text-center"} ${extra}`}
+                  >
+                    {label}
+                  </th>
+                )
+              })}
               {/* Arrow column */}
               <th className="w-10 pr-6" />
             </tr>

--- a/src/routes/_app/browse/$department/$course/index.tsx
+++ b/src/routes/_app/browse/$department/$course/index.tsx
@@ -79,7 +79,7 @@ function ClassRow({
   const sectionCount = classData.class.sections[0]?.count ?? 0
   return (
     <tr key={classData.class.id} className="group">
-      <td className="min-w-[16rem] pl-6 pr-3 py-4 align-top">
+      <td className="pl-6 pr-3 py-4 align-top">
         <Link
           to="/browse/$department/$course/$class"
           params={{
@@ -93,18 +93,18 @@ function ClassRow({
             {classData.class.name}
           </span>
           {classData.class.description && (
-            <p className="mt-0.5 text-xs text-muted-foreground">
+            <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
               {classData.class.description}
             </p>
           )}
         </Link>
       </td>
-      <td className="whitespace-nowrap px-3 py-4 text-center">
+      <td className="hidden md:table-cell whitespace-nowrap px-3 py-4 text-center">
         <Badge variant="outline" className="text-xs">
           {classData.code}
         </Badge>
       </td>
-      <td className="whitespace-nowrap px-3 py-4 text-center">
+      <td className="hidden sm:table-cell whitespace-nowrap px-3 py-4 text-center">
         {classData.class.cfu ? (
           <span className="text-sm text-muted-foreground">
             {classData.class.cfu}
@@ -191,7 +191,12 @@ function CoursePage() {
     10,
   )
 
-  const tableHeaders = ["Nome", "Codice", "CFU", "Sezioni"]
+  const tableHeaders = [
+    "Nome",
+    { label: "Codice", className: "hidden md:table-cell" },
+    { label: "CFU", className: "hidden sm:table-cell" },
+    "Sezioni",
+  ]
 
   return (
     <div className="pb-8">

--- a/src/routes/_app/browse/$department/index.tsx
+++ b/src/routes/_app/browse/$department/index.tsx
@@ -216,12 +216,20 @@ function DepartmentPage() {
                     {courses.length} {courses.length === 1 ? "corso" : "corsi"}
                   </span>
                 </div>
-                <BrowseTable headers={["Nome", "Codice", "CFU", "Sede", "Insegnamenti"]}>
+                <BrowseTable
+                  headers={[
+                    "Nome",
+                    { label: "Codice", className: "hidden md:table-cell" },
+                    { label: "CFU", className: "hidden sm:table-cell" },
+                    { label: "Sede", className: "hidden lg:table-cell" },
+                    "Insegnamenti",
+                  ]}
+                >
                   {pagedCourses.map((course) => {
                       const classCount = course.course_classes[0]?.count ?? 0
                       return (
                         <tr key={course.id} className="group">
-                          <td className="min-w-[16rem] pl-6 pr-3 py-4 align-top">
+                          <td className="pl-6 pr-3 py-4 align-top">
                             <Link
                               to="/browse/$department/$course"
                               params={{
@@ -234,18 +242,18 @@ function DepartmentPage() {
                                 {course.name}
                               </span>
                               {course.description && (
-                                <p className="mt-0.5 text-xs text-muted-foreground">
+                                <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
                                   {course.description}
                                 </p>
                               )}
                             </Link>
                           </td>
-                          <td className="whitespace-nowrap px-3 py-4 text-center">
+                          <td className="hidden md:table-cell whitespace-nowrap px-3 py-4 text-center">
                             <Badge variant="outline" className="text-xs">
                               {course.code}
                             </Badge>
                           </td>
-                          <td className="whitespace-nowrap px-3 py-4 text-center">
+                          <td className="hidden sm:table-cell whitespace-nowrap px-3 py-4 text-center">
                             {course.cfu ? (
                               <span className="text-sm text-muted-foreground">
                                 {course.cfu}
@@ -254,7 +262,7 @@ function DepartmentPage() {
                               <span className="text-xs text-muted-foreground/50">—</span>
                             )}
                           </td>
-                          <td className="whitespace-nowrap px-3 py-4 text-center">
+                          <td className="hidden lg:table-cell whitespace-nowrap px-3 py-4 text-center">
                             {course.location ? (
                               <span className="text-sm text-muted-foreground">
                                 {CAMPUS_LOCATION_CONFIG[course.location]?.short ?? course.location}

--- a/src/routes/_app/search/classes/index.tsx
+++ b/src/routes/_app/search/classes/index.tsx
@@ -253,7 +253,17 @@ function SearchClassesPage() {
               initial="hidden"
               animate="visible"
             >
-              <BrowseTable headers={["Nome", "Codice", "Corso", "Anno", "CFU", "Tipo", "Sezioni"]}>
+              <BrowseTable
+                headers={[
+                  "Nome",
+                  { label: "Codice", className: "hidden lg:table-cell" },
+                  { label: "Corso", className: "hidden lg:table-cell" },
+                  { label: "Anno", className: "hidden md:table-cell" },
+                  { label: "CFU", className: "hidden md:table-cell" },
+                  { label: "Tipo", className: "hidden sm:table-cell" },
+                  "Sezioni",
+                ]}
+              >
                 {paged.map((cls) => {
                   const sectionCount = cls.sections[0]?.count ?? 0
                   return (
@@ -262,7 +272,7 @@ function SearchClassesPage() {
                       variants={withReducedMotion(staggerItem, prefersReduced)}
                       className="group"
                     >
-                      <td className="min-w-[16rem] pl-6 pr-3 py-4 align-top">
+                      <td className="pl-6 pr-3 py-4 align-top">
                         <Link
                           to="/browse/$department/$course/$class"
                           params={{
@@ -276,29 +286,29 @@ function SearchClassesPage() {
                             {cls.name}
                           </span>
                           {cls.description && (
-                            <p className="mt-0.5 text-xs text-muted-foreground">
+                            <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
                               {cls.description}
                             </p>
                           )}
                         </Link>
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden lg:table-cell whitespace-nowrap px-3 py-4 text-center">
                         <Badge variant="outline" className="text-xs">{cls.code}</Badge>
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden lg:table-cell whitespace-nowrap px-3 py-4 text-center">
                         <Badge variant="outline" className="text-xs">{cls.course.code}</Badge>
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden md:table-cell whitespace-nowrap px-3 py-4 text-center">
                         <span className="text-sm text-muted-foreground">{cls.class_year}°</span>
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden md:table-cell whitespace-nowrap px-3 py-4 text-center">
                         {cls.cfu ? (
                           <span className="text-sm text-muted-foreground">{cls.cfu}</span>
                         ) : (
                           <span className="text-xs text-muted-foreground/50">—</span>
                         )}
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden sm:table-cell whitespace-nowrap px-3 py-4 text-center">
                         <Badge variant={cls.mandatory ? "default" : "secondary"} className="text-xs">
                           {cls.mandatory ? "Obbligatorio" : "A scelta"}
                         </Badge>

--- a/src/routes/_app/search/courses/index.tsx
+++ b/src/routes/_app/search/courses/index.tsx
@@ -217,7 +217,17 @@ function SearchCoursesPage() {
               initial="hidden"
               animate="visible"
             >
-              <BrowseTable headers={["Nome", "Codice", "Dipartimento", "Tipo", "Campus", "CFU", "Insegnamenti"]}>
+              <BrowseTable
+                headers={[
+                  "Nome",
+                  { label: "Codice", className: "hidden md:table-cell" },
+                  { label: "Dipartimento", className: "hidden lg:table-cell" },
+                  { label: "Tipo", className: "hidden sm:table-cell" },
+                  { label: "Campus", className: "hidden lg:table-cell" },
+                  { label: "CFU", className: "hidden md:table-cell" },
+                  "Insegnamenti",
+                ]}
+              >
                 {paged.map((course) => {
                   const typeConf = COURSE_TYPE_CONFIG[course.course_type]
                   const classCount = course.course_classes[0]?.count ?? 0
@@ -227,7 +237,7 @@ function SearchCoursesPage() {
                       variants={withReducedMotion(staggerItem, prefersReduced)}
                       className="group"
                     >
-                      <td className="min-w-[16rem] pl-6 pr-3 py-4 align-top">
+                      <td className="pl-6 pr-3 py-4 align-top">
                         <Link
                           to="/browse/$department/$course"
                           params={{
@@ -241,20 +251,20 @@ function SearchCoursesPage() {
                           </span>
                         </Link>
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden md:table-cell whitespace-nowrap px-3 py-4 text-center">
                         <Badge variant="outline" className="text-xs">{course.code}</Badge>
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden lg:table-cell whitespace-nowrap px-3 py-4 text-center">
                         <Badge variant="outline" className="text-xs">{course.department.code}</Badge>
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden sm:table-cell whitespace-nowrap px-3 py-4 text-center">
                         {typeConf ? (
                           <Badge className={cn("text-xs", typeConf.className)}>{typeConf.label}</Badge>
                         ) : (
                           <span className="text-xs text-muted-foreground">{course.course_type}</span>
                         )}
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden lg:table-cell whitespace-nowrap px-3 py-4 text-center">
                         {course.location ? (
                           <span className="text-sm text-muted-foreground">
                             {CAMPUS_LOCATION_CONFIG[course.location]?.short ?? course.location}
@@ -263,7 +273,7 @@ function SearchCoursesPage() {
                           <span className="text-xs text-muted-foreground/50">—</span>
                         )}
                       </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-center">
+                      <td className="hidden md:table-cell whitespace-nowrap px-3 py-4 text-center">
                         {course.cfu ? (
                           <span className="text-sm text-muted-foreground">{course.cfu}</span>
                         ) : (


### PR DESCRIPTION
## Summary

- **Reverted regression in body font size** introduced by `dd500b5`: `BrowseTable` body was promoted to `text-sm md:text-base`, making the Name column visibly heavier on desktop. Restored uniform `text-sm`.
- **Restored homogeneous row heights** broken by `9dbfcd4`: that commit dropped the description `truncate` and pinned the first cell to `min-w-[16rem]`, so descriptions wrapped over multiple lines and rows had inconsistent heights. Description is now `line-clamp-1`, and the min-width is removed (the existing `w-[40%]` on the first header column keeps the Name column wide).
- **Replaced mobile horizontal scroll with progressive column disclosure**. `BrowseTable` now accepts richer headers — `Array<string | { label: string; className?: string }>` — so each consumer marks columns with `hidden sm:table-cell`, `hidden md:table-cell`, or `hidden lg:table-cell`. Matching `<td>`s carry the same class.

### Visibility matrix

| Table | Always | sm (≥640) | md (≥768) | lg (≥1024) |
|---|---|---|---|---|
| Browse Department | Name, Insegnamenti | + CFU | + Codice | + Sede |
| Browse Course | Name, Sezioni | + CFU | + Codice | — |
| Search Courses | Name, Insegnamenti | + Tipo | + Codice, CFU | + Dipartimento, Campus |
| Search Classes | Name, Sezioni | + Tipo | + Anno, CFU | + Codice, Corso |

## Design system

Aligned with [docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md):
- `text-sm` for dense tabular text.
- `hidden [breakpoint]:table-cell` follows the existing `hidden [breakpoint]:block` progressive disclosure pattern used elsewhere in the codebase.
- No changes to spacing, radii, focus states, motion, or color tokens.

## Test plan

- [ ] **Desktop (≥1024px)**: all columns visible, Name font is 14px (no longer 16px on `md+`), descriptions clamp to one line, row heights are uniform.
- [ ] **Tablet (768–1023px / md)**: Browse Department hides Sede; Search Courses hides Dipartimento + Campus.
- [ ] **Tablet small (640–767px / sm)**: Browse Department hides Codice + Sede; Search Classes shows only Name + Tipo + Sezioni.
- [ ] **Mobile (<640px)**: each table shows Name + the primary count + arrow, no horizontal scroll.
- [ ] Dark theme: no visual regression on tables.
- [ ] Pages to check: `/browse/{department}`, `/browse/{department}/{course}`, `/search/courses?q=...`, `/search/classes?q=...`.