### PR TITLE
fix(sections): resolve section page 404s caused by hyphens in the name

### DIFF
--- a/src/lib/browse/server.ts
+++ b/src/lib/browse/server.ts
@@ -300,13 +300,12 @@ export const getSectionDetailFn = createServerFn({ method: "GET" })
 
     const classData = courseClassRow.class as any
 
-    // Find section by slug (hyphens → spaces)
-    const sectionName = data.sectionSlug.replace(/-/g, " ")
+    // Resolve section by its stored slug (exact match, scoped to the class).
     const { data: section } = await catalogQuery(supabase)
       .from("sections")
       .select("*")
       .eq("class_id", classData.id)
-      .ilike("name", sectionName)
+      .eq("slug", data.sectionSlug.toLowerCase())
       .single()
 
     if (!section) return null

--- a/src/lib/quiz/server.ts
+++ b/src/lib/quiz/server.ts
@@ -430,7 +430,8 @@ export const getQuizResultsFn = createServerFn({ method: "GET" })
       .eq("quiz_attempt_id", data.attemptId)
 
     // Get evaluation mode and slug components in parallel
-    const [evalModeRes, deptRes, courseRes, classRes] = await Promise.all([
+    const [evalModeRes, deptRes, courseRes, classRes, sectionRes] =
+      await Promise.all([
       quizQuery(supabase)
         .from("evaluation_modes")
         .select("*")
@@ -458,15 +459,20 @@ export const getQuizResultsFn = createServerFn({ method: "GET" })
             .eq("course_id", attempt.course_id)
             .single()
         : Promise.resolve({ data: null }),
+      attempt.section_id
+        ? catalogQuery(supabase)
+            .from("sections")
+            .select("slug")
+            .eq("id", attempt.section_id)
+            .single()
+        : Promise.resolve({ data: null }),
     ])
     const evalMode = evalModeRes.data
     const deptCode = deptRes.data?.code
     const courseCode = courseRes.data?.code
     const classCode = classRes.data?.code
 
-    const sectionSlug = attempt.section_name
-      ? attempt.section_name.replace(/ /g, "-").toLowerCase()
-      : null
+    const sectionSlug = sectionRes.data?.slug ?? null
     const sectionPath =
       deptCode && courseCode && classCode && sectionSlug
         ? `/browse/${deptCode.toLowerCase()}/${courseCode.toLowerCase()}/${classCode.toLowerCase()}/${sectionSlug}`

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -370,6 +370,7 @@ export type Database = {
           is_public: boolean
           name: string
           position: number
+          slug: string
           updated_at: string
         }
         Insert: {
@@ -380,6 +381,7 @@ export type Database = {
           is_public?: boolean
           name: string
           position?: number
+          slug?: never
           updated_at?: string
         }
         Update: {
@@ -390,6 +392,7 @@ export type Database = {
           is_public?: boolean
           name?: string
           position?: number
+          slug?: never
           updated_at?: string
         }
         Relationships: [

--- a/src/routes/_app/admin/sections/$sectionId.tsx
+++ b/src/routes/_app/admin/sections/$sectionId.tsx
@@ -81,7 +81,7 @@ function AdminSectionDetailPage() {
   const courseClass = cls.course_classes?.[0]
   const course = courseClass?.course
   const department = course?.department
-  const sectionSlug = section.name.replace(/ /g, "-").toLowerCase()
+  const sectionSlug = section.slug
 
   // Section access management (only for private sections)
   const { data: accessUsers } = useQuery({

--- a/src/routes/_app/browse/$department/$course/$class/index.tsx
+++ b/src/routes/_app/browse/$department/$course/$class/index.tsx
@@ -288,9 +288,7 @@ function ClassPage() {
         <>
         <BrowseTable headers={["Sezione", "Quiz", "Flashcard", "Totale"]}>
           {paged.map((section) => {
-            const sectionSlug = section.name
-              .replace(/ /g, "-")
-              .toLowerCase()
+            const sectionSlug = section.slug
             return (
               <tr key={section.id} className="group">
                 <td className="pl-6 py-4">

--- a/supabase/migrations/00018_sections_slug.sql
+++ b/supabase/migrations/00018_sections_slug.sql
@@ -1,0 +1,21 @@
+-- Add a derived, unique slug to catalog.sections.
+-- Browse URLs (/browse/.../$section) previously resolved a section by reversing
+-- its name slug (all hyphens -> spaces), which 404'd any section whose name
+-- itself contained hyphens (e.g. "Host-to-Network"). A stored slug column lets
+-- the route resolve by exact match instead of a lossy reverse.
+
+BEGIN;
+
+-- Same transform the app used to build the slug: lowercase, spaces -> hyphens.
+-- Generated + stored so it stays in sync with name and is populated automatically
+-- on every insert (admin UI and manual SQL seeding alike).
+ALTER TABLE catalog.sections
+  ADD COLUMN slug TEXT
+  GENERATED ALWAYS AS (lower(replace(name, ' ', '-'))) STORED;
+
+-- Slugs are scoped to the parent class: routes resolve a section within a class,
+-- so two different classes may each have e.g. an "introduzione" section.
+CREATE UNIQUE INDEX sections_class_id_slug_key
+  ON catalog.sections (class_id, slug);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Fixes the 404 reported in #99 — e.g. `/browse/dief/20-312/inf-021r/host-to-network`.

**Root cause.** Section pages resolved a section by *reversing* its URL slug (`slug.replace(/-/g, " ")`) and matching the result against `sections.name` with `ilike`. But the slug was built with the opposite, **non-invertible** transform (`name.replace(/ /g, "-")`). So any section whose name contained a literal hyphen (e.g. `Host-to-Network`) produced a slug that, once reversed, no longer matched the name → `notFound()` → 404. Names made only of space-separated words worked by coincidence.

**Fix.** Stop relying on the lossy reverse — store the slug and resolve by exact match.

- **Migration `00018_sections_slug.sql`** — adds `slug TEXT GENERATED ALWAYS AS (lower(replace(name, ' ', '-'))) STORED` plus a unique index on `(class_id, slug)`. Generated + stored means it is always populated automatically (admin UI **and** manual SQL seeding) and stays in sync with `name`. Slugs are unique per class, since routes resolve a section within its parent class.
- **Resolution** (`getSectionDetailFn`) — now `.eq("slug", sectionSlug.toLowerCase())` instead of the `ilike` on the reversed name.
- **Link generation** — the browse class table and the admin section page now read `section.slug` instead of re-deriving it. The quiz-results path fetches the slug by `section_id` (more correct than the denormalized `section_name`, which can go stale on rename).

**URL / SEO impact: none — only positive.** The generated slug uses the *same* transform the app already produced, so every existing URL is unchanged: no redirects, no re-indexing. The only behavioral change is that previously-broken pages now return `200` instead of a soft-404.

Closes #99
