### PR TITLE
feat: markdown question previews and admin report detail

### DIFF
--- a/src/lib/requests/server.ts
+++ b/src/lib/requests/server.ts
@@ -6,7 +6,7 @@ import { getSupabaseAdmin, getCatalogAdmin } from "@/lib/supabase/admin"
 import { createServerSupabaseClient, catalogQuery } from "@/lib/supabase/server"
 
 import { storedContentSchema } from "./schemas"
-import type { AdminContentRequest, ContentRequestWithMeta, SubmittedContent } from "./types"
+import type { AdminContentRequest, ContentRequestWithMeta, ReportedQuestion, SubmittedContent } from "./types"
 
 /** Validate JSONB content from DB against Zod schema at runtime */
 function parseSubmittedContent(raw: unknown): SubmittedContent {
@@ -380,7 +380,17 @@ export const getRequestDetailFn = createServerFn({ method: "GET" })
     const target_label = await buildTargetLabel(supabase, request)
     const submitted = parseSubmittedContent(request.submitted_content)
 
-    return { ...request, target_label, submitted }
+    let reported_question: ReportedQuestion | null = null
+    if (submitted.type === "report") {
+      const { data: question } = await catalogQuery(supabase)
+        .from("questions")
+        .select("id, content, question_type, options, correct_answer, explanation, difficulty")
+        .eq("id", submitted.question_id)
+        .single()
+      if (question) reported_question = question as ReportedQuestion
+    }
+
+    return { ...request, target_label, submitted, reported_question }
   })
 
 // ─── Admin Mutations ───

--- a/src/lib/requests/types.ts
+++ b/src/lib/requests/types.ts
@@ -33,6 +33,16 @@ export type SubmittedReport = {
   comment: string | null
 }
 
+export type ReportedQuestion = {
+  id: string
+  content: string
+  question_type: "MULTIPLE_CHOICE" | "TRUE_FALSE" | "SHORT_ANSWER"
+  options: string[] | null
+  correct_answer: string[]
+  explanation: string | null
+  difficulty: "EASY" | "MEDIUM" | "HARD"
+}
+
 export type SubmittedFileUpload = {
   type: "file_upload"
   file_name: string
@@ -47,6 +57,7 @@ export type SubmittedContent = SubmittedSection | SubmittedQuestions | Submitted
 export type ContentRequestWithMeta = ContentRequest & {
   target_label: string
   submitted: SubmittedContent
+  reported_question?: ReportedQuestion | null
 }
 
 // Admin view includes user info

--- a/src/routes/_app/admin/requests/$requestId.tsx
+++ b/src/routes/_app/admin/requests/$requestId.tsx
@@ -2,11 +2,12 @@ import { useState } from "react"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { seoHead } from "@/lib/seo"
-import { ArrowLeft, CheckCircle2, Download, Eye, FileUp, MapPin, Pencil, Settings2 } from "lucide-react"
+import { ArrowLeft, CheckCircle2, ChevronDown, Download, Eye, FileUp, MapPin, Pencil, Settings2 } from "lucide-react"
 
 import { AdminPageHeader } from "@/components/admin/admin-page-header"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { HandleRequestDialog } from "@/components/requests/handle-request-dialog"
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer"
 import { RequestStatusBadge } from "@/components/requests/request-status-badge"
@@ -15,6 +16,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { requestQueries } from "@/lib/requests/queries"
 import { useAcknowledgeRequest, useApproveRequest } from "@/lib/requests/mutations"
 import { getFileDownloadUrlFn } from "@/lib/requests/server"
+import { isCorrectOption, parseOptions } from "@/lib/quiz/options"
 import { cn } from "@/lib/utils"
 import { toast } from "sonner"
 
@@ -216,7 +218,7 @@ function ContentPreview({
           </div>
 
           {reportedQuestion ? (
-            <QuestionCard question={reportedQuestion} index={0} label={null} />
+            <ReportedQuestionCard question={reportedQuestion} />
           ) : (
             <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 space-y-2">
               <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
@@ -250,29 +252,15 @@ function ContentPreview({
   )
 }
 
-function QuestionCard({
-  question,
-  index,
-  label,
-}: {
-  question: SubmittedQuestion
-  index: number
-  /** Heading text; pass null to hide it (keeps the type/difficulty badges). */
-  label?: string | null
-}) {
+function QuestionCard({ question, index }: { question: SubmittedQuestion; index: number }) {
   const typeLabels = { MULTIPLE_CHOICE: "Scelta multipla", TRUE_FALSE: "Vero/Falso", SHORT_ANSWER: "Risposta breve" }
   const diffColors = { EASY: "text-green-500", MEDIUM: "text-amber-500", HARD: "text-red-500" }
   const diffLabels = { EASY: "Facile", MEDIUM: "Medio", HARD: "Difficile" }
-  const heading = label === undefined ? `Domanda ${index + 1}` : label
 
   return (
     <div className="rounded-xl border p-4 space-y-3">
       <div className="flex items-center justify-between">
-        {heading !== null ? (
-          <p className="text-xs font-semibold text-muted-foreground">{heading}</p>
-        ) : (
-          <span />
-        )}
+        <p className="text-xs font-semibold text-muted-foreground">Domanda {index + 1}</p>
         <div className="flex gap-1.5">
           <Badge variant="outline" className="rounded-full text-[10px]">
             {typeLabels[question.question_type]}
@@ -335,6 +323,76 @@ function QuestionCard({
           <MarkdownRenderer content={question.explanation} className="mt-0.5 text-sm" />
         </div>
       )}
+    </div>
+  )
+}
+
+function ReportedQuestionCard({ question }: { question: ReportedQuestion }) {
+  const [open, setOpen] = useState(false)
+  const options = parseOptions(question.options)
+  const typeLabels = { MULTIPLE_CHOICE: "Scelta multipla", TRUE_FALSE: "Vero/Falso", SHORT_ANSWER: "Risposta breve" }
+  const diffColors = { EASY: "text-green-500", MEDIUM: "text-amber-500", HARD: "text-red-500" }
+  const diffLabels = { EASY: "Facile", MEDIUM: "Medio", HARD: "Difficile" }
+
+  return (
+    <div className="rounded-xl border p-4 space-y-3">
+      <div className="flex items-center justify-end gap-1.5">
+        <Badge variant="outline" className="rounded-full text-[10px]">
+          {typeLabels[question.question_type]}
+        </Badge>
+        <Badge variant="outline" className={cn("rounded-full text-[10px]", diffColors[question.difficulty])}>
+          {diffLabels[question.difficulty]}
+        </Badge>
+      </div>
+
+      <MarkdownRenderer content={question.content} className="text-sm font-medium" />
+
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger asChild>
+          <Button variant="outline" size="sm" className="w-full justify-between gap-1.5 rounded-xl">
+            {open ? "Nascondi opzioni e risposta" : "Mostra opzioni e risposta"}
+            <ChevronDown className={cn("size-4 transition-transform", open && "rotate-180")} />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="space-y-1.5 pt-2">
+          {options.length > 0 ? (
+            options.map((option, oi) => {
+              const isCorrect = isCorrectOption(option.id, question.correct_answer)
+              return (
+                <div
+                  key={oi}
+                  className={cn(
+                    "flex items-center gap-2 rounded-lg px-3 py-2 text-sm",
+                    isCorrect
+                      ? "border border-green-500/30 bg-green-500/10 font-medium text-green-700 dark:text-green-400"
+                      : "bg-muted/50",
+                  )}
+                >
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {String.fromCharCode(65 + oi)}
+                  </span>
+                  <MarkdownRenderer content={option.text} inline />
+                  {isCorrect && (
+                    <CheckCircle2 className="ml-auto size-4 shrink-0 text-green-500" />
+                  )}
+                </div>
+              )
+            })
+          ) : (
+            <div className="rounded-lg border border-green-500/30 bg-green-500/10 px-3 py-2 text-sm text-green-700 dark:text-green-400">
+              <span className="font-medium">Risposta corretta: </span>
+              {question.correct_answer.join(", ")}
+            </div>
+          )}
+
+          {question.explanation && (
+            <div className="rounded-lg bg-muted/50 px-3 py-2">
+              <p className="text-xs font-medium text-muted-foreground">Spiegazione</p>
+              <MarkdownRenderer content={question.explanation} className="mt-0.5 text-sm" />
+            </div>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   )
 }

--- a/src/routes/_app/admin/requests/$requestId.tsx
+++ b/src/routes/_app/admin/requests/$requestId.tsx
@@ -2,12 +2,13 @@ import { useState } from "react"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { seoHead } from "@/lib/seo"
-import { ArrowLeft, CheckCircle2, Download, Eye, FileUp, MapPin, Settings2 } from "lucide-react"
+import { ArrowLeft, CheckCircle2, Download, Eye, FileUp, MapPin, Pencil, Settings2 } from "lucide-react"
 
 import { AdminPageHeader } from "@/components/admin/admin-page-header"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { HandleRequestDialog } from "@/components/requests/handle-request-dialog"
+import { MarkdownRenderer } from "@/components/ui/markdown-renderer"
 import { RequestStatusBadge } from "@/components/requests/request-status-badge"
 import { RequestTypeBadge } from "@/components/requests/request-type-badge"
 import { Textarea } from "@/components/ui/textarea"
@@ -17,7 +18,7 @@ import { getFileDownloadUrlFn } from "@/lib/requests/server"
 import { cn } from "@/lib/utils"
 import { toast } from "sonner"
 
-import type { SubmittedContent, SubmittedFileUpload, SubmittedQuestion } from "@/lib/requests/types"
+import type { ReportedQuestion, SubmittedContent, SubmittedFileUpload, SubmittedQuestion } from "@/lib/requests/types"
 
 export const Route = createFileRoute("/_app/admin/requests/$requestId")({
   loader: ({ context, params }) =>
@@ -118,7 +119,10 @@ function AdminRequestDetailPage() {
         <h3 className="text-sm font-semibold uppercase tracking-widest text-primary">
           {isReport ? "Dettagli segnalazione" : isFileUpload ? "File caricato" : "Contenuto proposto"}
         </h3>
-        <ContentPreview submitted={request.submitted} />
+        <ContentPreview
+          submitted={request.submitted}
+          reportedQuestion={request.reported_question ?? null}
+        />
       </div>
 
       {/* Acknowledge section (reports + file uploads) */}
@@ -169,7 +173,13 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function ContentPreview({ submitted }: { submitted: SubmittedContent }) {
+function ContentPreview({
+  submitted,
+  reportedQuestion,
+}: {
+  submitted: SubmittedContent
+  reportedQuestion?: ReportedQuestion | null
+}) {
   if (submitted.type === "file_upload") {
     return <FileUploadPreview file={submitted} />
   }
@@ -190,9 +200,31 @@ function ContentPreview({ submitted }: { submitted: SubmittedContent }) {
             <p className="text-sm">{submitted.comment}</p>
           </div>
         )}
-        <div className="rounded-xl border p-4">
-          <p className="text-xs font-medium text-muted-foreground mb-1">Domanda segnalata</p>
-          <p className="text-sm">{submitted.question_content}</p>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs font-medium text-muted-foreground">Domanda segnalata</p>
+            <Button asChild variant="outline" size="sm" className="gap-1.5 rounded-xl">
+              <Link
+                to="/admin/questions/$questionId"
+                params={{ questionId: submitted.question_id }}
+              >
+                <Pencil className="size-3.5" />
+                Modifica domanda
+              </Link>
+            </Button>
+          </div>
+
+          {reportedQuestion ? (
+            <QuestionCard question={reportedQuestion} index={0} label={null} />
+          ) : (
+            <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 space-y-2">
+              <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+                La domanda non è più disponibile (potrebbe essere stata eliminata o modificata). Contenuto al momento della segnalazione:
+              </p>
+              <MarkdownRenderer content={submitted.question_content} className="text-sm" />
+            </div>
+          )}
         </div>
       </div>
     )
@@ -218,15 +250,29 @@ function ContentPreview({ submitted }: { submitted: SubmittedContent }) {
   )
 }
 
-function QuestionCard({ question, index }: { question: SubmittedQuestion; index: number }) {
+function QuestionCard({
+  question,
+  index,
+  label,
+}: {
+  question: SubmittedQuestion
+  index: number
+  /** Heading text; pass null to hide it (keeps the type/difficulty badges). */
+  label?: string | null
+}) {
   const typeLabels = { MULTIPLE_CHOICE: "Scelta multipla", TRUE_FALSE: "Vero/Falso", SHORT_ANSWER: "Risposta breve" }
   const diffColors = { EASY: "text-green-500", MEDIUM: "text-amber-500", HARD: "text-red-500" }
   const diffLabels = { EASY: "Facile", MEDIUM: "Medio", HARD: "Difficile" }
+  const heading = label === undefined ? `Domanda ${index + 1}` : label
 
   return (
     <div className="rounded-xl border p-4 space-y-3">
       <div className="flex items-center justify-between">
-        <p className="text-xs font-semibold text-muted-foreground">Domanda {index + 1}</p>
+        {heading !== null ? (
+          <p className="text-xs font-semibold text-muted-foreground">{heading}</p>
+        ) : (
+          <span />
+        )}
         <div className="flex gap-1.5">
           <Badge variant="outline" className="rounded-full text-[10px]">
             {typeLabels[question.question_type]}
@@ -237,7 +283,7 @@ function QuestionCard({ question, index }: { question: SubmittedQuestion; index:
         </div>
       </div>
 
-      <p className="text-sm font-medium">{question.content}</p>
+      <MarkdownRenderer content={question.content} className="text-sm font-medium" />
 
       {/* Options */}
       {question.options && question.options.length > 0 && (
@@ -258,9 +304,9 @@ function QuestionCard({ question, index }: { question: SubmittedQuestion; index:
                 <span className="font-mono text-xs text-muted-foreground">
                   {optId.toUpperCase()}
                 </span>
-                {opt}
+                <MarkdownRenderer content={opt} inline />
                 {isCorrect && (
-                  <CheckCircle2 className="ml-auto size-4 text-green-500" />
+                  <CheckCircle2 className="ml-auto size-4 shrink-0 text-green-500" />
                 )}
               </div>
             )
@@ -286,7 +332,7 @@ function QuestionCard({ question, index }: { question: SubmittedQuestion; index:
       {question.explanation && (
         <div className="rounded-lg bg-muted/50 px-3 py-2">
           <p className="text-xs font-medium text-muted-foreground">Spiegazione</p>
-          <p className="mt-0.5 text-sm">{question.explanation}</p>
+          <MarkdownRenderer content={question.explanation} className="mt-0.5 text-sm" />
         </div>
       )}
     </div>

--- a/src/routes/_app/quiz.results.$attemptId.tsx
+++ b/src/routes/_app/quiz.results.$attemptId.tsx
@@ -237,9 +237,11 @@ function ReviewItem({
           <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-muted text-sm font-semibold">
             {index + 1}
           </span>
-          <span className="line-clamp-1 min-w-0 flex-1 text-sm font-medium">
-            <MarkdownRenderer content={question.content} inline />
-          </span>
+          {!open && (
+            <span className="line-clamp-1 min-w-0 flex-1 text-sm font-medium">
+              <MarkdownRenderer content={question.content} inline />
+            </span>
+          )}
         </div>
         <ResultBadge
           isCorrect={isCorrect}

--- a/src/routes/_app/quiz.results.$attemptId.tsx
+++ b/src/routes/_app/quiz.results.$attemptId.tsx
@@ -237,11 +237,9 @@ function ReviewItem({
           <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-muted text-sm font-semibold">
             {index + 1}
           </span>
-          {!open && (
-            <span className="line-clamp-1 min-w-0 flex-1 text-sm font-medium">
-              <MarkdownRenderer content={question.content} inline />
-            </span>
-          )}
+          <span className={`min-w-0 flex-1 text-sm font-medium ${open ? "" : "line-clamp-1"}`}>
+            <MarkdownRenderer content={question.content} inline />
+          </span>
         </div>
         <ResultBadge
           isCorrect={isCorrect}
@@ -253,23 +251,15 @@ function ReviewItem({
 
       {open && (
         <div className="border-t px-4 pb-4 pt-3 space-y-3">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 flex-1 text-sm">
-              <MarkdownRenderer
-                content={question.content}
-                className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
-              />
-            </div>
-            <div
-              className="flex shrink-0 items-center gap-1"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <BookmarkButton questionId={question.id} />
-              <ReportButton
-                questionId={question.id}
-                questionContent={question.content}
-              />
-            </div>
+          <div
+            className="flex items-center justify-end gap-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <BookmarkButton questionId={question.id} />
+            <ReportButton
+              questionId={question.id}
+              questionContent={question.content}
+            />
           </div>
           {options.length > 0 && (
             <ul className="space-y-1.5">

--- a/src/routes/_app/user/bookmarks.tsx
+++ b/src/routes/_app/user/bookmarks.tsx
@@ -106,10 +106,11 @@ function BookmarkCard({
         className="flex w-full items-center justify-between gap-3 p-4 text-left transition-colors hover:bg-muted/30"
       >
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          <span className="line-clamp-1 text-sm font-medium">
-            {bookmark.content.slice(0, 100)}
-            {bookmark.content.length > 100 && "..."}
-          </span>
+          {!open && (
+            <span className="line-clamp-1 min-w-0 flex-1 text-sm font-medium">
+              <MarkdownRenderer content={bookmark.content} inline />
+            </span>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Badge

--- a/src/routes/_app/user/bookmarks.tsx
+++ b/src/routes/_app/user/bookmarks.tsx
@@ -106,11 +106,9 @@ function BookmarkCard({
         className="flex w-full items-center justify-between gap-3 p-4 text-left transition-colors hover:bg-muted/30"
       >
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          {!open && (
-            <span className="line-clamp-1 min-w-0 flex-1 text-sm font-medium">
-              <MarkdownRenderer content={bookmark.content} inline />
-            </span>
-          )}
+          <span className={`min-w-0 flex-1 text-sm font-medium ${open ? "" : "line-clamp-1"}`}>
+            <MarkdownRenderer content={bookmark.content} inline />
+          </span>
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Badge
@@ -165,14 +163,6 @@ function BookmarkCard({
                 <Bookmark className="h-4 w-4 fill-current" />
               </Button>
             </div>
-          </div>
-
-          {/* Question content */}
-          <div className="text-sm">
-            <MarkdownRenderer
-              content={bookmark.content}
-              className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
-            />
           </div>
 
           {/* Options */}


### PR DESCRIPTION
## Summary
- Admin report detail now loads the live question by `question_id` and shows content, options (correct answer highlighted), and explanation in Markdown, inside a collapsible block, with a link to edit the question.
- Bookmarks and quiz results now render the header preview in Markdown and no longer duplicate the question text (it lives in the header only).

## Files
- `src/lib/requests/types.ts`, `src/lib/requests/server.ts` — `ReportedQuestion` type + live question fetch
- `src/routes/_app/admin/requests/$requestId.tsx` — report rendering + `ReportedQuestionCard`
- `src/routes/_app/user/bookmarks.tsx`, `src/routes/_app/quiz.results.$attemptId.tsx` — MD preview + dedup

## Test
- `tsc --noEmit` clean (pre-existing unrelated `admin-sidebar.tsx` error remains).