### PR TITLE
feat: role-based access control for admin and maintainer users

### DIFF
--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -13,9 +13,11 @@ import {
   Shield,
   Trophy,
   Users,
+  type LucideIcon,
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useAuth } from "@/hooks/useAuth"
 import { adminQueries } from "@/lib/admin/queries"
 import { requestQueries } from "@/lib/requests/queries"
 import type {
@@ -25,9 +27,22 @@ import type {
 } from "@/lib/admin/types"
 
 export function AdminSidebar() {
+  const { user } = useAuth()
+  const isSuperadmin = user?.role === "SUPERADMIN"
+  const isMaintainer = user?.role === "MAINTAINER"
   const { data: stats } = useQuery(adminQueries.stats())
-  const { data: userStats } = useQuery(adminQueries.userStats())
-  const { data: tree } = useQuery(adminQueries.contentTree())
+  // SUPERADMIN-only (getAdminUserStatsFn); gating prevents requireSuperadmin
+  // from redirecting MAINTAINER/ADMIN users to /user.
+  const { data: userStats } = useQuery({
+    ...adminQueries.userStats(),
+    enabled: isSuperadmin,
+  })
+  // Maintainers manage their own courses (shown in the dashboard), not
+  // departments — skip the tree for them entirely.
+  const { data: tree } = useQuery({
+    ...adminQueries.contentTree(),
+    enabled: !isMaintainer,
+  })
   const matchRoute = useMatchRoute()
 
   const { data: requestCount } = useQuery(requestQueries.adminRequestCount())
@@ -55,24 +70,28 @@ export function AdminSidebar() {
           Dashboard
         </Link>
 
-        {/* Dipartimenti — with file tree */}
-        <DepartmentsTreeLink
-          isActive={!!isDeptActive}
-          tree={tree}
-          departmentCount={stats?.departmentCount}
-        />
+        {/* Dipartimenti — with file tree (hidden for maintainers) */}
+        {!isMaintainer && (
+          <DepartmentsTreeLink
+            isActive={!!isDeptActive}
+            tree={tree}
+            departmentCount={stats?.departmentCount}
+          />
+        )}
 
-        {/* Utenti */}
-        <Link
-          to="/admin/users"
-          className={cn(
-            "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors hover:bg-accent/50",
-            isUsersActive && "bg-primary/10 text-primary font-semibold",
-          )}
-        >
-          <Users className="h-4 w-4" />
-          Utenti
-        </Link>
+        {/* Utenti — SUPERADMIN only (/admin/users requires superadmin) */}
+        {isSuperadmin && (
+          <Link
+            to="/admin/users"
+            className={cn(
+              "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors hover:bg-accent/50",
+              isUsersActive && "bg-primary/10 text-primary font-semibold",
+            )}
+          >
+            <Users className="h-4 w-4" />
+            Utenti
+          </Link>
+        )}
 
         {/* Richieste */}
         <Link
@@ -106,17 +125,19 @@ export function AdminSidebar() {
         </div>
       </div>
 
-      {/* Stats: Utenti */}
-      <div className="border-t border-border/50 pt-4">
-        <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-widest text-primary">
-          Utenti
-        </p>
-        <div className="flex flex-col gap-0.5">
-          <SidebarStat icon={Users} label="Registrati" count={userStats?.totalUsers} />
-          <SidebarStat icon={Shield} label="Admin" count={(userStats?.byRole?.SUPERADMIN ?? 0) + (userStats?.byRole?.ADMIN ?? 0) + (userStats?.byRole?.MAINTAINER ?? 0)} />
-          <SidebarStat icon={Trophy} label="Quiz completati" count={userStats?.totalQuizAttempts} />
+      {/* Stats: Utenti — SUPERADMIN only */}
+      {isSuperadmin && (
+        <div className="border-t border-border/50 pt-4">
+          <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-widest text-primary">
+            Utenti
+          </p>
+          <div className="flex flex-col gap-0.5">
+            <SidebarStat icon={Users} label="Registrati" count={userStats?.totalUsers} />
+            <SidebarStat icon={Shield} label="Admin" count={(userStats?.byRole?.SUPERADMIN ?? 0) + (userStats?.byRole?.ADMIN ?? 0) + (userStats?.byRole?.MAINTAINER ?? 0)} />
+            <SidebarStat icon={Trophy} label="Quiz completati" count={userStats?.totalQuizAttempts} />
+          </div>
         </div>
-      </div>
+      )}
     </nav>
   )
 }
@@ -333,7 +354,7 @@ function SidebarStat({
   label,
   count,
 }: {
-  icon: React.ElementType
+  icon: LucideIcon
   label: string
   count?: number
 }) {

--- a/src/components/admin/forms/section-form.tsx
+++ b/src/components/admin/forms/section-form.tsx
@@ -22,6 +22,9 @@ type SectionFormProps = {
   classId: string
   onSubmit: (data: SectionInput) => void
   isPending: boolean
+  // Visibility (public/private) is an access-control decision; hidden from
+  // maintainers, who only manage public sections.
+  canEditVisibility?: boolean
 }
 
 export function SectionForm({
@@ -29,6 +32,7 @@ export function SectionForm({
   classId,
   onSubmit,
   isPending,
+  canEditVisibility = true,
 }: SectionFormProps) {
   const form = useForm<SectionInput>({
     resolver: standardSchemaResolver(sectionSchema),
@@ -73,27 +77,29 @@ export function SectionForm({
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="is_public"
-          render={({ field }) => (
-            <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
-              <FormControl>
-                <Checkbox
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                />
-              </FormControl>
-              <div className="space-y-1 leading-none">
-                <FormLabel>Pubblica</FormLabel>
-                <FormDescription>
-                  Le sezioni pubbliche sono accessibili a tutti gli utenti.
-                  Quelle private richiedono un accesso esplicito.
-                </FormDescription>
-              </div>
-            </FormItem>
-          )}
-        />
+        {canEditVisibility && (
+          <FormField
+            control={form.control}
+            name="is_public"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>Pubblica</FormLabel>
+                  <FormDescription>
+                    Le sezioni pubbliche sono accessibili a tutti gli utenti.
+                    Quelle private richiedono un accesso esplicito.
+                  </FormDescription>
+                </div>
+              </FormItem>
+            )}
+          />
+        )}
         <Button type="submit" disabled={isPending}>
           {isPending
             ? "Salvataggio..."

--- a/src/components/admin/maintainer-invite-dialog.tsx
+++ b/src/components/admin/maintainer-invite-dialog.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react"
+import { Mail, Send } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { useSendMaintainerInvite } from "@/lib/admin/mutations"
+import { buildMaintainerInviteDefaults } from "@/lib/email/templates/maintainer-invite"
+
+type InviteCourse = { id: string; name: string; code: string }
+
+export function MaintainerInviteDialog({
+  userId,
+  userName,
+  userEmail,
+  courses,
+}: {
+  userId: string
+  userName: string | null
+  userEmail: string | null
+  courses: InviteCourse[]
+}) {
+  const [open, setOpen] = useState(false)
+  const [courseId, setCourseId] = useState("")
+  const [subject, setSubject] = useState("")
+  const [body, setBody] = useState("")
+
+  const send = useSendMaintainerInvite(() => {
+    setOpen(false)
+  })
+
+  function reset() {
+    setCourseId("")
+    setSubject("")
+    setBody("")
+  }
+
+  // Regenerate the default subject/body from the selected course; the text is
+  // course-specific, so picking a course overwrites any previous draft.
+  function handleCourseChange(id: string) {
+    setCourseId(id)
+    const course = courses.find((c) => c.id === id)
+    if (course) {
+      const defaults = buildMaintainerInviteDefaults({
+        courseName: course.name,
+        inviteeName: userName,
+      })
+      setSubject(defaults.subject)
+      setBody(defaults.body)
+    }
+  }
+
+  const canSend =
+    !!userEmail && !!courseId && subject.trim().length >= 3 && body.trim().length >= 10
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) reset()
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline" className="gap-1.5 rounded-xl">
+          <Mail className="h-4 w-4" />
+          Invita come maintainer
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Invita come maintainer</DialogTitle>
+          <DialogDescription>
+            {userEmail
+              ? `L'email verrà inviata a ${userEmail}`
+              : "Questo utente non ha un indirizzo email: impossibile inviare l'invito."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Corso</Label>
+            <Select value={courseId} onValueChange={handleCourseChange}>
+              <SelectTrigger className="rounded-xl">
+                <SelectValue placeholder="Seleziona il corso..." />
+              </SelectTrigger>
+              <SelectContent>
+                {courses.length === 0 ? (
+                  <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                    Nessun corso disponibile
+                  </div>
+                ) : (
+                  courses.map((c) => (
+                    <SelectItem key={c.id} value={c.id}>
+                      {c.name} ({c.code})
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="invite-subject">Oggetto</Label>
+            <Input
+              id="invite-subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Oggetto dell'email"
+              disabled={!courseId}
+              className="rounded-xl"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="invite-body">Messaggio</Label>
+            <Textarea
+              id="invite-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Seleziona un corso per generare il testo predefinito, poi modificalo liberamente."
+              disabled={!courseId}
+              rows={14}
+              className="rounded-xl text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              Testo predefinito modificabile prima dell'invio.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost" className="rounded-xl">
+              Annulla
+            </Button>
+          </DialogClose>
+          <Button
+            className="gap-1.5 rounded-xl"
+            disabled={!canSend || send.isPending}
+            onClick={() =>
+              send.mutate({ user_id: userId, course_id: courseId, subject, body })
+            }
+          >
+            <Send className="h-4 w-4" />
+            {send.isPending ? "Invio..." : "Invia email"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -3,6 +3,7 @@ import {
   Bell,
   CheckCircle2,
   FileEdit,
+  GraduationCap,
   Inbox,
   MessageSquare,
   RefreshCw,
@@ -26,6 +27,7 @@ const typeConfig: Record<
   REQUEST_REVISED: { icon: RefreshCw, color: "text-purple-500" },
   CONTENT_UPDATED: { icon: Sparkles, color: "text-primary" },
   NEW_SECTION_ADDED: { icon: MessageSquare, color: "text-primary" },
+  MAINTAINER_ASSIGNED: { icon: GraduationCap, color: "text-primary" },
 }
 
 function timeAgo(dateStr: string): string {

--- a/src/lib/admin/mutations.ts
+++ b/src/lib/admin/mutations.ts
@@ -24,6 +24,7 @@ import {
   removeCourseMaintainerFn,
   removeDepartmentAdminFn,
   removeSectionAccessFn,
+  sendMaintainerInviteFn,
   deleteUserFn,
   updateClassFn,
   updateCourseClassFn,
@@ -282,6 +283,14 @@ export function useRemoveCourseMaintainer(onSuccess?: () => void) {
   return useMutationWithToast(removeCourseMaintainerFn, {
     successMessage: "Maintainer corso rimosso",
     invalidateKeys: USER_INVALIDATE_KEYS,
+    onSuccess,
+  })
+}
+
+export function useSendMaintainerInvite(onSuccess?: () => void) {
+  return useMutationWithToast(sendMaintainerInviteFn, {
+    successMessage: "Email di invito inviata",
+    invalidateKeys: [],
     onSuccess,
   })
 }

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -11,6 +11,7 @@ import {
   getAdminQuestionDetailFn,
   getAdminSectionDetailFn,
   getAdminStatsFn,
+  getMyMaintainedCoursesFn,
   getAdminUserDetailFn,
   getAdminUserStatsFn,
   getAdminUsersFn,
@@ -39,6 +40,13 @@ export const adminQueries = {
     queryOptions({
       queryKey: ["admin", "permissions"],
       queryFn: () => getAdminPermissionsFn(),
+      staleTime: STALE_TIME.STANDARD,
+    }),
+
+  myMaintainedCourses: () =>
+    queryOptions({
+      queryKey: ["admin", "myMaintainedCourses"],
+      queryFn: () => getMyMaintainedCoursesFn(),
       staleTime: STALE_TIME.STANDARD,
     }),
 

--- a/src/lib/admin/schemas.ts
+++ b/src/lib/admin/schemas.ts
@@ -224,3 +224,18 @@ export const sectionAccessSchema = z.object({
   user_id: z.string().min(1),
   section_id: z.string().min(1),
 })
+
+export const maintainerInviteSchema = z.object({
+  user_id: z.string().min(1),
+  course_id: z.string().min(1, "Il corso è obbligatorio"),
+  subject: z
+    .string()
+    .trim()
+    .min(3, "L'oggetto è obbligatorio")
+    .max(200, "L'oggetto non può superare i 200 caratteri"),
+  body: z
+    .string()
+    .trim()
+    .min(10, "Il messaggio è troppo corto")
+    .max(5000, "Il messaggio non può superare i 5000 caratteri"),
+})

--- a/src/lib/admin/server/access.ts
+++ b/src/lib/admin/server/access.ts
@@ -60,10 +60,15 @@ export async function assertSectionScope(
   if (user.role !== "MAINTAINER") return
   const { data, error } = await getCatalogAdmin()
     .from("sections")
-    .select("class_id")
+    .select("class_id, is_public")
     .eq("id", sectionId)
     .single()
   if (error || !data) throw new Error("Sezione non trovata")
+  // Private sections are access-controlled (superadmin domain); off-limits to
+  // maintainers.
+  if (!data.is_public) {
+    throw new Error("Non puoi gestire sezioni private.")
+  }
   await assertClassScope(user, data.class_id)
 }
 

--- a/src/lib/admin/server/access.ts
+++ b/src/lib/admin/server/access.ts
@@ -1,0 +1,103 @@
+import { requireAdmin } from "@/lib/auth/guards"
+import { getCatalogAdmin } from "@/lib/supabase/admin"
+import type { AuthUser } from "@/lib/auth/types"
+
+// ─── Content authorization ───
+//
+// Role model for the admin catalog:
+//   • Courses + classes (the structural catalog) are managed by ADMIN and
+//     SUPERADMIN. Maintainers are content-only and are rejected for these.
+//   • Sections + questions are managed by ADMIN, SUPERADMIN and MAINTAINER.
+//     For a MAINTAINER, access is scoped: the owning class must belong to at
+//     least one course they maintain (a class can be shared across courses).
+//
+// ADMIN/SUPERADMIN remain unscoped (unchanged behavior). All resolution uses
+// the service-role catalog client since this is server-side authorization.
+
+// Structural catalog (courses + classes) — ADMIN+ only.
+export async function requireStructureManager(): Promise<AuthUser> {
+  const user = await requireAdmin()
+  if (user.role === "MAINTAINER") {
+    throw new Error("I maintainer non possono modificare corsi o insegnamenti.")
+  }
+  return user
+}
+
+async function maintainedCourseIds(userId: string): Promise<Set<string>> {
+  const { data } = await getCatalogAdmin()
+    .from("course_maintainers")
+    .select("course_id")
+    .eq("user_id", userId)
+  return new Set((data ?? []).map((r) => r.course_id))
+}
+
+// No-op for ADMIN/SUPERADMIN; for a MAINTAINER, requires that the class belongs
+// to at least one course they maintain.
+async function assertClassScope(user: AuthUser, classId: string): Promise<void> {
+  if (user.role !== "MAINTAINER") return
+
+  const [{ data: links }, maintained] = await Promise.all([
+    getCatalogAdmin()
+      .from("course_classes")
+      .select("course_id")
+      .eq("class_id", classId),
+    maintainedCourseIds(user.id),
+  ])
+
+  const inScope = (links ?? []).some((l) => maintained.has(l.course_id))
+  if (!inScope) {
+    throw new Error(
+      "Non hai i permessi per gestire i contenuti di questo insegnamento.",
+    )
+  }
+}
+
+// Exposed for bulk operations that span multiple sections.
+export async function assertSectionScope(
+  user: AuthUser,
+  sectionId: string,
+): Promise<void> {
+  if (user.role !== "MAINTAINER") return
+  const { data, error } = await getCatalogAdmin()
+    .from("sections")
+    .select("class_id")
+    .eq("id", sectionId)
+    .single()
+  if (error || !data) throw new Error("Sezione non trovata")
+  await assertClassScope(user, data.class_id)
+}
+
+// ─── Content CRUD entry guards (sections + questions) ───
+
+export async function requireContentManagerForClass(
+  classId: string,
+): Promise<AuthUser> {
+  const user = await requireAdmin()
+  await assertClassScope(user, classId)
+  return user
+}
+
+export async function requireContentManagerForSection(
+  sectionId: string,
+): Promise<AuthUser> {
+  const user = await requireAdmin()
+  await assertSectionScope(user, sectionId)
+  return user
+}
+
+export async function requireContentManagerForQuestion(
+  questionId: string,
+): Promise<AuthUser> {
+  const user = await requireAdmin()
+  if (user.role !== "MAINTAINER") return user
+
+  const { data, error } = await getCatalogAdmin()
+    .from("questions")
+    .select("section_id")
+    .eq("id", questionId)
+    .single()
+  if (error || !data) throw new Error("Domanda non trovata")
+
+  await assertSectionScope(user, data.section_id)
+  return user
+}

--- a/src/lib/admin/server/classes.ts
+++ b/src/lib/admin/server/classes.ts
@@ -3,6 +3,7 @@ import { createServerFn } from "@tanstack/react-start"
 import { requireAdmin } from "@/lib/auth/guards"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
+import { requireStructureManager } from "./access"
 import {
   classSchema,
   courseClassSchema,
@@ -53,7 +54,7 @@ export const getAdminClassDetailFn = createServerFn({ method: "GET" })
 export const createClassFn = createServerFn({ method: "POST" })
   .inputValidator(classSchema)
   .handler(async ({ data }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const { data: cls, error } = await catalogQuery(supabase)
@@ -96,7 +97,7 @@ export const createClassFn = createServerFn({ method: "POST" })
 export const createExamSimulationSentinelFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const { data: cls, error: clsError } = await catalogQuery(supabase)
@@ -137,7 +138,7 @@ export const createExamSimulationSentinelFn = createServerFn({ method: "POST" })
 export const updateClassFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema.merge(updateClassSchema))
   .handler(async ({ data: { id, ...updates } }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const updateData: Record<string, unknown> = {}
@@ -167,7 +168,7 @@ export const updateClassFn = createServerFn({ method: "POST" })
 export const deleteClassFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const { count } = await catalogQuery(supabase)
@@ -190,7 +191,7 @@ export const deleteClassFn = createServerFn({ method: "POST" })
 export const addClassToCourseFn = createServerFn({ method: "POST" })
   .inputValidator(courseClassSchema)
   .handler(async ({ data }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const { data: row, error } = await catalogQuery(supabase)
@@ -223,7 +224,7 @@ export const updateCourseClassFn = createServerFn({ method: "POST" })
     courseClassSchema.pick({ course_id: true, class_id: true }).merge(updateCourseClassSchema),
   )
   .handler(async ({ data: { course_id, class_id, ...updates } }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const updateData: Record<string, unknown> = {}
@@ -253,7 +254,7 @@ export const removeClassFromCourseFn = createServerFn({ method: "POST" })
     courseClassSchema.pick({ course_id: true, class_id: true }),
   )
   .handler(async ({ data }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const { error } = await catalogQuery(supabase)

--- a/src/lib/admin/server/courses.ts
+++ b/src/lib/admin/server/courses.ts
@@ -3,6 +3,7 @@ import { createServerFn } from "@tanstack/react-start"
 import { requireAdmin } from "@/lib/auth/guards"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
+import { requireStructureManager } from "./access"
 import { courseSchema, idSchema, updateCourseSchema } from "../schemas"
 
 // ─── Courses ───
@@ -23,7 +24,7 @@ export const getAdminCourseDetailFn = createServerFn({ method: "GET" })
 
     const { data: courseClasses, error: classesError } = await catalogQuery(supabase)
       .from("course_classes")
-      .select("*, class:classes(*, sections(count))")
+      .select("*, class:classes(*, sections(name))")
       .eq("course_id", id)
       .order("position")
 
@@ -35,7 +36,7 @@ export const getAdminCourseDetailFn = createServerFn({ method: "GET" })
 export const createCourseFn = createServerFn({ method: "POST" })
   .inputValidator(courseSchema)
   .handler(async ({ data }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const { count } = await catalogQuery(supabase)
@@ -71,7 +72,7 @@ export const createCourseFn = createServerFn({ method: "POST" })
 export const updateCourseFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema.merge(updateCourseSchema))
   .handler(async ({ data: { id, ...updates } }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const updateData: Record<string, unknown> = {}
@@ -106,7 +107,7 @@ export const updateCourseFn = createServerFn({ method: "POST" })
 export const deleteCourseFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const { count } = await catalogQuery(supabase)

--- a/src/lib/admin/server/courses.ts
+++ b/src/lib/admin/server/courses.ts
@@ -24,7 +24,7 @@ export const getAdminCourseDetailFn = createServerFn({ method: "GET" })
 
     const { data: courseClasses, error: classesError } = await catalogQuery(supabase)
       .from("course_classes")
-      .select("*, class:classes(*, sections(name))")
+      .select("*, class:classes(*, sections(name, is_public))")
       .eq("course_id", id)
       .order("position")
 

--- a/src/lib/admin/server/dashboard.ts
+++ b/src/lib/admin/server/dashboard.ts
@@ -25,7 +25,10 @@ export const getAdminStatsFn = createServerFn({ method: "GET" }).handler(
           .select("*", { count: "exact", head: true }),
         catalog.from("courses").select("*", { count: "exact", head: true }),
         catalog.from("classes").select("*", { count: "exact", head: true }),
-        catalog.from("sections").select("*", { count: "exact", head: true }),
+        catalog
+          .from("sections")
+          .select("*", { count: "exact", head: true })
+          .neq("name", "Exam Simulation"),
         catalog.from("questions").select("*", { count: "exact", head: true }),
       ])
 
@@ -68,6 +71,31 @@ export const getAdminPermissionsFn = createServerFn({
     ),
   }
 })
+
+// Courses the current user maintains, with names — used to show scoped links
+// in the admin sidebar instead of the full departments tree.
+export const getMyMaintainedCoursesFn = createServerFn({
+  method: "GET",
+}).handler(
+  async (): Promise<{ id: string; name: string; code: string }[]> => {
+    const user = await requireAdmin()
+    const supabase = createServerSupabaseClient()
+
+    const { data, error } = await catalogQuery(supabase)
+      .from("course_maintainers")
+      .select("course:courses(id, name, code)")
+      .eq("user_id", user.id)
+
+    if (error) throw new Error(error.message)
+
+    return (data ?? [])
+      .map(
+        (row) =>
+          row.course as unknown as { id: string; name: string; code: string },
+      )
+      .filter(Boolean)
+  },
+)
 
 // ─── Content Tree ───
 

--- a/src/lib/admin/server/questions.ts
+++ b/src/lib/admin/server/questions.ts
@@ -4,6 +4,11 @@ import { z } from "zod"
 import { requireAdmin } from "@/lib/auth/guards"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
+import {
+  assertSectionScope,
+  requireContentManagerForQuestion,
+  requireContentManagerForSection,
+} from "./access"
 import { idSchema, questionSchema, updateQuestionSchema } from "../schemas"
 
 // ─── Questions ───
@@ -29,7 +34,7 @@ export const getAdminQuestionDetailFn = createServerFn({ method: "GET" })
 export const createQuestionFn = createServerFn({ method: "POST" })
   .inputValidator(questionSchema)
   .handler(async ({ data }) => {
-    await requireAdmin()
+    await requireContentManagerForSection(data.section_id)
     const supabase = createServerSupabaseClient()
 
     const { data: question, error } = await catalogQuery(supabase)
@@ -54,7 +59,12 @@ export const createQuestionFn = createServerFn({ method: "POST" })
 export const createQuestionsBulkFn = createServerFn({ method: "POST" })
   .inputValidator(z.array(questionSchema))
   .handler(async ({ data: questions }) => {
-    await requireAdmin()
+    const user = await requireAdmin()
+    // Scope-check every distinct target section for maintainers.
+    const sectionIds = [...new Set(questions.map((q) => q.section_id))]
+    for (const sectionId of sectionIds) {
+      await assertSectionScope(user, sectionId)
+    }
     const supabase = createServerSupabaseClient()
 
     const rows = questions.map((q) => ({
@@ -80,7 +90,7 @@ export const createQuestionsBulkFn = createServerFn({ method: "POST" })
 export const updateQuestionFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema.merge(updateQuestionSchema))
   .handler(async ({ data: { id, ...updates } }) => {
-    await requireAdmin()
+    await requireContentManagerForQuestion(id)
     const supabase = createServerSupabaseClient()
 
     const updateData: Record<string, unknown> = {}
@@ -110,7 +120,7 @@ export const updateQuestionFn = createServerFn({ method: "POST" })
 export const deleteQuestionFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireContentManagerForQuestion(id)
     const supabase = createServerSupabaseClient()
 
     const { error } = await catalogQuery(supabase).from("questions").delete().eq("id", id)

--- a/src/lib/admin/server/sections.ts
+++ b/src/lib/admin/server/sections.ts
@@ -39,7 +39,10 @@ export const getAdminSectionDetailFn = createServerFn({ method: "GET" })
 export const createSectionFn = createServerFn({ method: "POST" })
   .inputValidator(sectionSchema)
   .handler(async ({ data }) => {
-    await requireContentManagerForClass(data.class_id)
+    const user = await requireContentManagerForClass(data.class_id)
+    if (user.role === "MAINTAINER" && data.is_public === false) {
+      throw new Error("I maintainer possono creare solo sezioni pubbliche.")
+    }
     const supabase = createServerSupabaseClient()
 
     const { count } = await catalogQuery(supabase)

--- a/src/lib/admin/server/sections.ts
+++ b/src/lib/admin/server/sections.ts
@@ -3,6 +3,10 @@ import { createServerFn } from "@tanstack/react-start"
 import { requireAdmin } from "@/lib/auth/guards"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
+import {
+  requireContentManagerForClass,
+  requireContentManagerForSection,
+} from "./access"
 import { idSchema, sectionSchema, updateSectionSchema } from "../schemas"
 
 // ─── Sections ───
@@ -35,7 +39,7 @@ export const getAdminSectionDetailFn = createServerFn({ method: "GET" })
 export const createSectionFn = createServerFn({ method: "POST" })
   .inputValidator(sectionSchema)
   .handler(async ({ data }) => {
-    await requireAdmin()
+    await requireContentManagerForClass(data.class_id)
     const supabase = createServerSupabaseClient()
 
     const { count } = await catalogQuery(supabase)
@@ -63,7 +67,7 @@ export const createSectionFn = createServerFn({ method: "POST" })
 export const updateSectionFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema.merge(updateSectionSchema))
   .handler(async ({ data: { id, ...updates } }) => {
-    await requireAdmin()
+    await requireContentManagerForSection(id)
     const supabase = createServerSupabaseClient()
 
     const updateData: Record<string, unknown> = {}
@@ -88,7 +92,7 @@ export const updateSectionFn = createServerFn({ method: "POST" })
 export const deleteSectionFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireContentManagerForSection(id)
     const supabase = createServerSupabaseClient()
 
     const { count } = await catalogQuery(supabase)

--- a/src/lib/admin/server/users.ts
+++ b/src/lib/admin/server/users.ts
@@ -150,12 +150,43 @@ export const updateUserRoleFn = createServerFn({ method: "POST" })
       .eq("id", id)
 
     if (error) throw new Error(error.message)
+
+    // Demotion cleanup: drop scope assignments the new role no longer permits.
+    // Otherwise a demoted user keeps orphaned grants that still leak access via
+    // RLS and stay hidden behind the role-based UI gate.
+    const catalog = getCatalogAdmin()
+    if (role === "STUDENT" || role === "MAINTAINER") {
+      const { error: deptError } = await catalog
+        .from("department_admins")
+        .delete()
+        .eq("user_id", id)
+      if (deptError) throw new Error(deptError.message)
+    }
+    if (role === "STUDENT") {
+      const { error: courseError } = await catalog
+        .from("course_maintainers")
+        .delete()
+        .eq("user_id", id)
+      if (courseError) throw new Error(courseError.message)
+    }
   })
 
 export const addDepartmentAdminFn = createServerFn({ method: "POST" })
   .inputValidator(departmentAdminSchema)
   .handler(async ({ data }) => {
     await requireSuperadmin()
+
+    const { data: target } = await getSupabaseAdmin()
+      .from("profiles")
+      .select("role")
+      .eq("id", data.user_id)
+      .single()
+    if (!target || (target.role !== "ADMIN" && target.role !== "SUPERADMIN")) {
+      throw new Error(
+        "Imposta prima il ruolo Admin per questo utente prima di assegnare un dipartimento.",
+      )
+    }
+
     const { error } = await getCatalogAdmin()
       .from("department_admins")
       .insert(data)
@@ -185,6 +216,18 @@ export const addCourseMaintainerFn = createServerFn({ method: "POST" })
   .inputValidator(courseMaintainerSchema)
   .handler(async ({ data }) => {
     await requireSuperadmin()
+
+    const { data: target } = await getSupabaseAdmin()
+      .from("profiles")
+      .select("role")
+      .eq("id", data.user_id)
+      .single()
+    if (!target || target.role === "STUDENT") {
+      throw new Error(
+        "Imposta prima un ruolo adeguato (almeno Maintainer) per questo utente prima di assegnare un corso.",
+      )
+    }
+
     const { error } = await getCatalogAdmin()
       .from("course_maintainers")
       .insert(data)

--- a/src/lib/admin/server/users.ts
+++ b/src/lib/admin/server/users.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start"
 
 import { requireAdmin, requireSuperadmin } from "@/lib/auth/guards"
+import { createNotification } from "@/lib/notifications/helpers"
 import { getCatalogAdmin, getQuizAdmin, getSupabaseAdmin } from "@/lib/supabase/admin"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
@@ -194,6 +195,23 @@ export const addCourseMaintainerFn = createServerFn({ method: "POST" })
       }
       throw new Error(error.message)
     }
+
+    // Notify the user they have been promoted to maintainer of this course
+    const { data: course } = await getCatalogAdmin()
+      .from("courses")
+      .select("name")
+      .eq("id", data.course_id)
+      .single()
+
+    await createNotification(getSupabaseAdmin(), {
+      userId: data.user_id,
+      type: "MAINTAINER_ASSIGNED",
+      title: "Sei stato nominato maintainer",
+      body: course?.name ? `Corso: ${course.name}` : undefined,
+      referenceId: data.course_id,
+      referenceType: "course",
+      link: `/admin/courses/${data.course_id}`,
+    })
   })
 
 export const removeCourseMaintainerFn = createServerFn({ method: "POST" })

--- a/src/lib/admin/server/users.ts
+++ b/src/lib/admin/server/users.ts
@@ -8,6 +8,7 @@ import {
   courseMaintainerSchema,
   departmentAdminSchema,
   idSchema,
+  maintainerInviteSchema,
   sectionAccessSchema,
   userRoleSchema,
 } from "../schemas"
@@ -206,6 +207,52 @@ export const removeCourseMaintainerFn = createServerFn({ method: "POST" })
       .eq("course_id", data.course_id)
 
     if (error) throw new Error(error.message)
+  })
+
+export const sendMaintainerInviteFn = createServerFn({ method: "POST" })
+  .inputValidator(maintainerInviteSchema)
+  .handler(async ({ data }) => {
+    await requireSuperadmin()
+
+    const { data: profile, error: profileError } = await getSupabaseAdmin()
+      .from("profiles")
+      .select("email")
+      .eq("id", data.user_id)
+      .single()
+
+    if (profileError || !profile?.email) {
+      throw new Error("Email dell'utente non trovata")
+    }
+
+    const { data: course } = await getCatalogAdmin()
+      .from("courses")
+      .select("name")
+      .eq("id", data.course_id)
+      .single()
+
+    const { renderMaintainerInviteHtml } = await import(
+      "@/lib/email/templates/maintainer-invite"
+    )
+    const { sendMail } = await import("@/lib/email/server")
+
+    const siteUrl = process.env.VITE_SITE_URL ?? "https://www.trivia-more.it"
+
+    try {
+      await sendMail({
+        to: profile.email,
+        subject: data.subject,
+        html: renderMaintainerInviteHtml({
+          body: data.body,
+          courseName: course?.name ?? "",
+          logoUrl: `${siteUrl}/logo192.png`,
+        }),
+        text: data.body,
+        replyTo: process.env.CONTACT_RECIPIENT,
+      })
+    } catch (err) {
+      console.error("Failed to send maintainer invite email:", err)
+      throw new Error("Errore durante l'invio dell'email. Riprova più tardi.")
+    }
   })
 
 export const addSectionAccessFn = createServerFn({ method: "POST" })

--- a/src/lib/email/templates/maintainer-invite.ts
+++ b/src/lib/email/templates/maintainer-invite.ts
@@ -1,0 +1,106 @@
+type MaintainerInviteDefaultsInput = {
+  courseName: string
+  inviteeName?: string | null
+}
+
+// Builds the default, editable subject + body for a maintainer invitation.
+// Kept client-safe (pure string logic) so the admin dialog can prefill it.
+export function buildMaintainerInviteDefaults({
+  courseName,
+  inviteeName,
+}: MaintainerInviteDefaultsInput): { subject: string; body: string } {
+  const greeting = inviteeName?.trim() ? `Ciao ${inviteeName.trim()},` : "Ciao,"
+  const subject = `Invito a diventare maintainer del corso ${courseName}`
+
+  const body = [
+    greeting,
+    "",
+    `ti scriviamo da TriviaMore perché vorremmo proporti di diventare maintainer del corso «${courseName}».`,
+    "",
+    "Cosa potrai fare come maintainer:",
+    "• Creare e modificare le sezioni e le domande del corso",
+    "• Revisionare e approvare le proposte di contenuto degli studenti",
+    "• Mantenere aggiornato il materiale didattico del corso",
+    "",
+    "Quali sono i vincoli:",
+    `• Il tuo accesso è limitato al corso «${courseName}»: non potrai gestire altri corsi o dipartimenti`,
+    "• Sei responsabile della qualità e della correttezza dei contenuti che pubblichi",
+    "• Il ruolo può essere revocato in qualsiasi momento dallo staff",
+    "",
+    "Se sei interessato/a, rispondi a questa email e procederemo con l'attivazione.",
+    "",
+    "Grazie,",
+    "Lo staff di TriviaMore",
+  ].join("\n")
+
+  return { subject, body }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+// Wraps the (possibly edited) plain-text body into the branded TriviaMore shell.
+// Only the body is user-editable; the header and footer stay fixed.
+export function renderMaintainerInviteHtml({
+  body,
+  courseName,
+  logoUrl,
+}: {
+  body: string
+  courseName: string
+  logoUrl: string
+}): string {
+  const safeBody = escapeHtml(body).replace(/\n/g, "<br />")
+  const safeCourse = escapeHtml(courseName)
+
+  return `<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Invito maintainer - ${safeCourse}</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#f6f4f1;font-family:'Poppins',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1a1a1a;">
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#f6f4f1;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="max-width:600px;background-color:#ffffff;border-radius:24px;overflow:hidden;box-shadow:0 8px 32px rgba(209,65,36,0.08);">
+            <tr>
+              <td style="padding:32px 40px 16px 40px;border-bottom:1px solid #f0ece8;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                  <tr>
+                    <td style="vertical-align:middle;">
+                      <img src="${logoUrl}" width="28" height="28" alt="TriviaMore" style="display:inline-block;vertical-align:middle;border:0;" />
+                      <span style="margin-left:8px;font-size:20px;font-weight:700;letter-spacing:-0.02em;color:#d14124;vertical-align:middle;">TriviaMore</span>
+                      <span style="margin-left:8px;font-size:13px;color:#8a8a8a;vertical-align:middle;">invito maintainer</span>
+                    </td>
+                    <td align="right" style="vertical-align:middle;">
+                      <span style="display:inline-block;padding:6px 12px;background-color:#fef3c7;color:#d97706;font-size:12px;font-weight:600;border-radius:999px;text-transform:uppercase;letter-spacing:0.05em;">${safeCourse}</span>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:32px 40px;font-size:14px;line-height:1.7;color:#2a2a2a;">
+                ${safeBody}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:20px 40px;background-color:#faf8f5;text-align:center;font-size:12px;color:#8a8a8a;">
+                <p style="margin:0;">Hai ricevuto questa email da TriviaMore. Per rispondere usa il pulsante "Rispondi" del tuo client di posta.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1184,6 +1184,7 @@ export type Database = {
         | "REQUEST_REVISED"
         | "CONTENT_UPDATED"
         | "NEW_SECTION_ADDED"
+        | "MAINTAINER_ASSIGNED"
       question_type: "MULTIPLE_CHOICE" | "TRUE_FALSE" | "SHORT_ANSWER"
       quiz_mode: "STUDY" | "EXAM_SIMULATION"
       role: "SUPERADMIN" | "ADMIN" | "MAINTAINER" | "STUDENT"
@@ -1630,6 +1631,7 @@ export const Constants = {
         "REQUEST_REVISED",
         "CONTENT_UPDATED",
         "NEW_SECTION_ADDED",
+        "MAINTAINER_ASSIGNED",
       ],
       question_type: ["MULTIPLE_CHOICE", "TRUE_FALSE", "SHORT_ANSWER"],
       quiz_mode: ["STUDY", "EXAM_SIMULATION"],

--- a/src/routes/_app/admin/classes/$classId.tsx
+++ b/src/routes/_app/admin/classes/$classId.tsx
@@ -40,6 +40,11 @@ import {
   useUpdateCourseClass,
 } from "@/lib/admin/mutations"
 import { adminQueries } from "@/lib/admin/queries"
+import { useAuth } from "@/hooks/useAuth"
+
+// Technical sentinel section auto-created with every class to anchor
+// exam-simulation quiz questions; hidden from the sections list.
+const EXAM_SIMULATION_NAME = "Exam Simulation"
 
 export const Route = createFileRoute("/_app/admin/classes/$classId")({
   loader: ({ context, params }) =>
@@ -53,6 +58,8 @@ export const Route = createFileRoute("/_app/admin/classes/$classId")({
 function AdminClassDetailPage() {
   const { classId } = Route.useParams()
   const { data } = useSuspenseQuery(adminQueries.class(classId))
+  const { user } = useAuth()
+  const isMaintainer = user?.role === "MAINTAINER"
   const [createSectionOpen, setCreateSectionOpen] = useState(false)
   const [deleteSectionId, setDeleteSectionId] = useState<string | null>(null)
   const [createExamSimulationOpen, setCreateExamSimulationOpen] = useState(false)
@@ -78,10 +85,16 @@ function AdminClassDetailPage() {
   const { sections, course_classes, ...cls } = data
   const courseClass = course_classes?.[0]
   const course = courseClass?.course
-  const hasExamSimulation = sections.some((s) => s.name === "Exam Simulation")
+  const hasExamSimulation = sections.some(
+    (s) => s.name === EXAM_SIMULATION_NAME,
+  )
+  // Hide the technical exam-simulation sentinel from the displayed list.
+  const visibleSections = sections.filter(
+    (s) => s.name !== EXAM_SIMULATION_NAME,
+  )
 
   const { paged, totalPages, safePage, totalItems } = usePaginatedSearch(
-    sections as SectionRow[],
+    visibleSections as SectionRow[],
     (s, q) => s.name.toLowerCase().includes(q),
     search,
     page,
@@ -112,6 +125,7 @@ function AdminClassDetailPage() {
       />
 
       <div className="grid gap-6">
+        {!isMaintainer && (
         <Card className="rounded-2xl">
           <CardHeader className="pb-4">
             <CardTitle>Modifica insegnamento</CardTitle>
@@ -143,11 +157,12 @@ function AdminClassDetailPage() {
             />
           </CardContent>
         </Card>
+        )}
 
         <Card className="rounded-2xl">
           <CardHeader>
             <div className="flex items-center justify-between gap-4">
-              <CardTitle>Sezioni ({sections.length})</CardTitle>
+              <CardTitle>Sezioni ({visibleSections.length})</CardTitle>
               <div className="flex items-center gap-2">
                 <div className="w-56">
                   <AdminSearch
@@ -159,7 +174,7 @@ function AdminClassDetailPage() {
                     placeholder="Cerca sezioni..."
                   />
                 </div>
-                {!hasExamSimulation && (
+                {!isMaintainer && !hasExamSimulation && (
                   <Button
                     size="sm"
                     variant="outline"

--- a/src/routes/_app/admin/classes/$classId.tsx
+++ b/src/routes/_app/admin/classes/$classId.tsx
@@ -88,9 +88,10 @@ function AdminClassDetailPage() {
   const hasExamSimulation = sections.some(
     (s) => s.name === EXAM_SIMULATION_NAME,
   )
-  // Hide the technical exam-simulation sentinel from the displayed list.
+  // Hide the exam-simulation sentinel, and (for maintainers) private sections,
+  // which they cannot manage.
   const visibleSections = sections.filter(
-    (s) => s.name !== EXAM_SIMULATION_NAME,
+    (s) => s.name !== EXAM_SIMULATION_NAME && (!isMaintainer || s.is_public),
   )
 
   const { paged, totalPages, safePage, totalItems } = usePaginatedSearch(
@@ -294,6 +295,7 @@ function AdminClassDetailPage() {
             classId={cls.id}
             onSubmit={(formData) => createSection.mutate(formData)}
             isPending={createSection.isPending}
+            canEditVisibility={!isMaintainer}
           />
         </DialogContent>
       </Dialog>

--- a/src/routes/_app/admin/courses/$courseId.tsx
+++ b/src/routes/_app/admin/courses/$courseId.tsx
@@ -82,9 +82,12 @@ function AdminCourseDetailPage() {
     class_year: cc.class_year,
     mandatory: cc.mandatory,
     curriculum: cc.curriculum,
-    // Real sections only — exclude the technical "Exam Simulation" sentinel.
-    sectionCount: ((cc.class.sections ?? []) as { name: string }[]).filter(
-      (s) => s.name !== "Exam Simulation",
+    // Real sections only: exclude the "Exam Simulation" sentinel, and (for
+    // maintainers) private sections, which they cannot manage.
+    sectionCount: (
+      (cc.class.sections ?? []) as { name: string; is_public: boolean }[]
+    ).filter(
+      (s) => s.name !== "Exam Simulation" && (!isMaintainer || s.is_public),
     ).length,
   })) as ClassRow[]
 

--- a/src/routes/_app/admin/courses/$courseId.tsx
+++ b/src/routes/_app/admin/courses/$courseId.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/lib/admin/mutations"
 import { addClassToCourseFn, createClassFn } from "@/lib/admin/server/classes"
 import { adminQueries } from "@/lib/admin/queries"
+import { useAuth } from "@/hooks/useAuth"
 
 export const Route = createFileRoute("/_app/admin/courses/$courseId")({
   loader: ({ context, params }) =>
@@ -52,6 +53,8 @@ export const Route = createFileRoute("/_app/admin/courses/$courseId")({
 function AdminCourseDetailPage() {
   const { courseId } = Route.useParams()
   const { data } = useSuspenseQuery(adminQueries.course(courseId))
+  const { user } = useAuth()
+  const isMaintainer = user?.role === "MAINTAINER"
   const [createClassOpen, setCreateClassOpen] = useState(false)
   const [deleteClassId, setDeleteClassId] = useState<string | null>(null)
   const [search, setSearch] = useState("")
@@ -62,7 +65,7 @@ function AdminCourseDetailPage() {
     name: string
     code: string
     class_year: number
-    sections: { count: number }[]
+    sectionCount: number
   }
 
   const { sort, toggleSort } = useSort<ClassRow>()
@@ -79,6 +82,10 @@ function AdminCourseDetailPage() {
     class_year: cc.class_year,
     mandatory: cc.mandatory,
     curriculum: cc.curriculum,
+    // Real sections only — exclude the technical "Exam Simulation" sentinel.
+    sectionCount: ((cc.class.sections ?? []) as { name: string }[]).filter(
+      (s) => s.name !== "Exam Simulation",
+    ).length,
   })) as ClassRow[]
 
   const { paged, totalPages, safePage, totalItems } = usePaginatedSearch(
@@ -96,9 +103,9 @@ function AdminCourseDetailPage() {
       <AdminPageHeader
         title={course.name}
         description={`${department.name} / ${course.code}`}
-        backTo="/admin/departments/$departmentId"
-        backParams={{ departmentId: department.id }}
-        backLabel={department.name}
+        backTo={isMaintainer ? "/admin" : "/admin/departments/$departmentId"}
+        backParams={isMaintainer ? undefined : { departmentId: department.id }}
+        backLabel={isMaintainer ? "Dashboard" : department.name}
         actions={
           <BrowsePublicButton
             to="/browse/$department/$course"
@@ -111,6 +118,7 @@ function AdminCourseDetailPage() {
       />
 
       <div className="grid gap-6">
+        {!isMaintainer && (
         <Card className="rounded-2xl">
           <CardHeader className="pb-4">
             <CardTitle>Modifica corso</CardTitle>
@@ -126,6 +134,7 @@ function AdminCourseDetailPage() {
             />
           </CardContent>
         </Card>
+        )}
 
         <Card className="rounded-2xl">
           <CardHeader>
@@ -142,10 +151,12 @@ function AdminCourseDetailPage() {
                     placeholder="Cerca insegnamenti..."
                   />
                 </div>
-                <Button size="sm" className="rounded-xl" onClick={() => setCreateClassOpen(true)}>
-                  <Plus className="mr-1 h-4 w-4" />
-                  Nuova
-                </Button>
+                {!isMaintainer && (
+                  <Button size="sm" className="rounded-xl" onClick={() => setCreateClassOpen(true)}>
+                    <Plus className="mr-1 h-4 w-4" />
+                    Nuova
+                  </Button>
+                )}
               </div>
             </div>
           </CardHeader>
@@ -170,8 +181,12 @@ function AdminCourseDetailPage() {
                       <TableHead className="text-center">
                         <SortableHeader label="Anno" sortKey="class_year" sort={sort} onSort={toggleSort} />
                       </TableHead>
-                      <TableHead className="text-center text-xs font-medium uppercase tracking-wider">Sezioni</TableHead>
-                      <TableHead className="text-right text-xs font-medium uppercase tracking-wider">Azioni</TableHead>
+                      <TableHead className="text-center">
+                        <SortableHeader label="Sezioni" sortKey="sectionCount" sort={sort} onSort={toggleSort} />
+                      </TableHead>
+                      {!isMaintainer && (
+                        <TableHead className="text-right text-xs font-medium uppercase tracking-wider">Azioni</TableHead>
+                      )}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -193,28 +208,30 @@ function AdminCourseDetailPage() {
                           {cls.class_year}
                         </TableCell>
                         <TableCell className="text-center">
-                          {cls.sections?.[0]?.count ?? 0}
+                          {cls.sectionCount}
                         </TableCell>
-                        <TableCell className="text-right">
-                          <div className="flex items-center justify-end gap-1">
-                            <Button variant="ghost" size="icon" className="rounded-lg" asChild>
-                              <Link
-                                to="/admin/classes/$classId"
-                                params={{ classId: cls.id }}
+                        {!isMaintainer && (
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-1">
+                              <Button variant="ghost" size="icon" className="rounded-lg" asChild>
+                                <Link
+                                  to="/admin/classes/$classId"
+                                  params={{ classId: cls.id }}
+                                >
+                                  <Pencil className="h-4 w-4" />
+                                </Link>
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="rounded-lg"
+                                onClick={() => setDeleteClassId(cls.id)}
                               >
-                                <Pencil className="h-4 w-4" />
-                              </Link>
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="rounded-lg"
-                              onClick={() => setDeleteClassId(cls.id)}
-                            >
-                              <Trash2 className="h-4 w-4 text-destructive" />
-                            </Button>
-                          </div>
-                        </TableCell>
+                                <Trash2 className="h-4 w-4 text-destructive" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        )}
                       </TableRow>
                     ))}
                   </TableBody>

--- a/src/routes/_app/admin/index.tsx
+++ b/src/routes/_app/admin/index.tsx
@@ -1,7 +1,8 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
 import { seoHead } from "@/lib/seo"
 import {
+  ArrowRight,
   BookOpen,
   FileQuestion,
   FolderOpen,
@@ -15,6 +16,18 @@ import {
 
 import { AdminPageHeader } from "@/components/admin/admin-page-header"
 import { AdminStatCard } from "@/components/admin/admin-stat-card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useAuth } from "@/hooks/useAuth"
 import { adminQueries } from "@/lib/admin/queries"
 
 export const Route = createFileRoute("/_app/admin/")({
@@ -25,8 +38,16 @@ export const Route = createFileRoute("/_app/admin/")({
 })
 
 function AdminDashboard() {
+  const { user } = useAuth()
+  const isSuperadmin = user?.role === "SUPERADMIN"
   const { data: stats } = useSuspenseQuery(adminQueries.stats())
-  const { data: userStats } = useQuery(adminQueries.userStats())
+  // User stats are SUPERADMIN-only (getAdminUserStatsFn). Running this query as
+  // a MAINTAINER/ADMIN would trigger requireSuperadmin's redirect to /user.
+  const { data: userStats } = useQuery({
+    ...adminQueries.userStats(),
+    enabled: isSuperadmin,
+  })
+  const { data: myCourses } = useQuery(adminQueries.myMaintainedCourses())
 
   const contentCards = [
     { label: "Dipartimenti", value: stats.departmentCount, icon: Library, to: "/admin/departments", color: "blue" },
@@ -106,6 +127,72 @@ function AdminDashboard() {
             />
           </div>
         </>
+      )}
+
+      {/* My maintained courses */}
+      {(myCourses ?? []).length > 0 && (
+        <div className="mt-8">
+          <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-primary">
+            I miei corsi mantenuti
+          </p>
+          <Card className="overflow-hidden rounded-2xl">
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/50">
+                    <TableHead className="text-xs font-medium uppercase tracking-wider">
+                      Corso
+                    </TableHead>
+                    <TableHead className="text-xs font-medium uppercase tracking-wider">
+                      Codice
+                    </TableHead>
+                    <TableHead className="text-right text-xs font-medium uppercase tracking-wider">
+                      Azioni
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {(myCourses ?? []).map((course) => (
+                    <TableRow
+                      key={course.id}
+                      className="transition-colors hover:bg-muted/30"
+                    >
+                      <TableCell>
+                        <Link
+                          to="/admin/courses/$courseId"
+                          params={{ courseId: course.id }}
+                          className="font-medium hover:underline"
+                        >
+                          {course.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className="rounded-full">
+                          {course.code}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="rounded-lg"
+                          asChild
+                        >
+                          <Link
+                            to="/admin/courses/$courseId"
+                            params={{ courseId: course.id }}
+                          >
+                            <ArrowRight className="h-4 w-4" />
+                          </Link>
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
       )}
     </div>
   )

--- a/src/routes/_app/admin/sections/$sectionId.tsx
+++ b/src/routes/_app/admin/sections/$sectionId.tsx
@@ -39,6 +39,7 @@ import {
   useUpdateSection,
 } from "@/lib/admin/mutations"
 import { adminQueries } from "@/lib/admin/queries"
+import { useAuth } from "@/hooks/useAuth"
 import type { Question } from "@/lib/admin/types"
 
 const DIFFICULTY_LABELS: Record<string, string> = {
@@ -65,6 +66,8 @@ export const Route = createFileRoute("/_app/admin/sections/$sectionId")({
 function AdminSectionDetailPage() {
   const { sectionId } = Route.useParams()
   const { data } = useSuspenseQuery(adminQueries.section(sectionId))
+  const { user } = useAuth()
+  const isSuperadmin = user?.role === "SUPERADMIN"
   const [deleteQuestionId, setDeleteQuestionId] = useState<string | null>(null)
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(1)
@@ -86,11 +89,11 @@ function AdminSectionDetailPage() {
   // Section access management (only for private sections)
   const { data: accessUsers } = useQuery({
     ...adminQueries.sectionAccessUsers(sectionId),
-    enabled: !section.is_public,
+    enabled: !section.is_public && isSuperadmin,
   })
   const { data: allUsers } = useQuery({
     ...adminQueries.users(),
-    enabled: !section.is_public,
+    enabled: !section.is_public && isSuperadmin,
   })
 
   const { paged, totalPages, safePage, totalItems } = usePaginatedSearch(
@@ -202,8 +205,8 @@ function AdminSectionDetailPage() {
           </Card>
         </div>
 
-        {/* Section access management (only for private sections) */}
-        {!section.is_public && (
+        {/* Section access management (private sections, SUPERADMIN only) */}
+        {!section.is_public && isSuperadmin && (
           <Card className="rounded-2xl">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">

--- a/src/routes/_app/admin/sections/$sectionId.tsx
+++ b/src/routes/_app/admin/sections/$sectionId.tsx
@@ -68,6 +68,7 @@ function AdminSectionDetailPage() {
   const { data } = useSuspenseQuery(adminQueries.section(sectionId))
   const { user } = useAuth()
   const isSuperadmin = user?.role === "SUPERADMIN"
+  const isMaintainer = user?.role === "MAINTAINER"
   const [deleteQuestionId, setDeleteQuestionId] = useState<string | null>(null)
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(1)
@@ -142,6 +143,7 @@ function AdminSectionDetailPage() {
                   updateSection.mutate({ id: section.id, ...formData })
                 }
                 isPending={updateSection.isPending}
+                canEditVisibility={!isMaintainer}
               />
             </CardContent>
           </Card>

--- a/src/routes/_app/admin/users/$userId.tsx
+++ b/src/routes/_app/admin/users/$userId.tsx
@@ -51,6 +51,16 @@ function AdminUserDetailPage() {
   const { user: currentUser } = useAuth()
   const isSuperadmin = currentUser?.role === "SUPERADMIN"
 
+  // Action visibility follows the role hierarchy: a department admin is an
+  // ADMIN-level concept, a course maintainer is MAINTAINER-level. Students see
+  // neither — the role must be raised first.
+  const canManageDepartments =
+    user.role === "ADMIN" || user.role === "SUPERADMIN"
+  const canMaintainCourses =
+    user.role === "MAINTAINER" ||
+    user.role === "ADMIN" ||
+    user.role === "SUPERADMIN"
+
   const [roleConfirm, setRoleConfirm] = useState<UserRole | null>(null)
   const [addDeptId, setAddDeptId] = useState("")
   const [addCourseId, setAddCourseId] = useState("")
@@ -206,7 +216,8 @@ function AdminUserDetailPage() {
           </Card>
         </div>
 
-        {/* Department Admin assignments */}
+        {/* Department Admin assignments — ADMIN+ only */}
+        {canManageDepartments && (
         <Card className="rounded-2xl">
           <CardHeader className="flex flex-row items-center justify-between">
             <div>
@@ -281,8 +292,10 @@ function AdminUserDetailPage() {
             )}
           </CardContent>
         </Card>
+        )}
 
-        {/* Course Maintainer assignments */}
+        {/* Course Maintainer assignments — MAINTAINER+ only */}
+        {canMaintainCourses && (
         <Card className="rounded-2xl">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -355,6 +368,7 @@ function AdminUserDetailPage() {
             )}
           </CardContent>
         </Card>
+        )}
 
         {/* Section Access */}
         <Card className="rounded-2xl">

--- a/src/routes/_app/admin/users/$userId.tsx
+++ b/src/routes/_app/admin/users/$userId.tsx
@@ -5,6 +5,7 @@ import { seoHead } from "@/lib/seo"
 import { BookOpen, GraduationCap, Library, Plus, Trash2, Trophy } from "lucide-react"
 
 import { AdminPageHeader } from "@/components/admin/admin-page-header"
+import { MaintainerInviteDialog } from "@/components/admin/maintainer-invite-dialog"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -146,6 +147,21 @@ function AdminUserDetailPage() {
                     {ROLE_LABELS[user.role]}
                   </Badge>
                 )}
+                {user.role === "STUDENT" && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Assegna un ruolo (Maintainer o Admin) per gestire corsi e
+                    dipartimenti.
+                  </p>
+                )}
+              </div>
+
+              <div className="mt-4">
+                <MaintainerInviteDialog
+                  userId={userId}
+                  userName={user.name}
+                  userEmail={user.email}
+                  courses={availableCourses}
+                />
               </div>
             </CardContent>
           </Card>

--- a/supabase/migrations/00019_maintainer_assigned_notification.sql
+++ b/supabase/migrations/00019_maintainer_assigned_notification.sql
@@ -1,0 +1,6 @@
+-- ============================================================
+-- Notification type fired when an admin assigns a user as
+-- maintainer of a course (manual promotion flow).
+-- ============================================================
+
+ALTER TYPE public.notification_type ADD VALUE IF NOT EXISTS 'MAINTAINER_ASSIGNED';

--- a/supabase/migrations/00020_protect_profile_role_allow_service_role.sql
+++ b/supabase/migrations/00020_protect_profile_role_allow_service_role.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- Allow role changes performed via the service-role connection.
+--
+-- The admin server fn updateUserRoleFn already enforces requireSuperadmin()
+-- at the application layer and updates profiles through the service-role
+-- client, where auth.uid() is NULL — so public.is_superadmin() returned false
+-- and the trigger raised "Only superadmins can change roles".
+--
+-- The trigger still blocks authenticated non-superadmins (RLS already limits
+-- them to their own row; this prevents self role escalation). Trusting the
+-- service-role connection mirrors the notifications_insert RLS policy.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.protect_profile_role()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public', 'catalog', 'quiz'
+AS $function$
+BEGIN
+  IF OLD.role IS DISTINCT FROM NEW.role THEN
+    IF NOT public.is_superadmin()
+       AND current_setting('role', true) <> 'service_role' THEN
+      RAISE EXCEPTION 'Only superadmins can change roles';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
This pull request introduces role-based access control for admin and maintainer users, refines the admin sidebar and forms to reflect these permissions, and adds the ability for admins to invite maintainers via email. It also improves notification handling and adds backend authorization logic to enforce these rules. The most important changes are summarized below.

---

**Role-based Access Control and Admin UI Improvements**

* The `AdminSidebar` now conditionally fetches and displays data based on the user's role: only SUPERADMINs see user stats and management links, and maintainers do not see department trees. (`src/components/admin/admin-sidebar.tsx`) [[1]](diffhunk://#diff-0d33194856a71c2a1202fcdda47be67ae38ac734922f0b3a1621aff685a49584R30-R45) [[2]](diffhunk://#diff-0d33194856a71c2a1202fcdda47be67ae38ac734922f0b3a1621aff685a49584L58-R83) [[3]](diffhunk://#diff-0d33194856a71c2a1202fcdda47be67ae38ac734922f0b3a1621aff685a49584L109-R129)
* The `SectionForm` now supports a `canEditVisibility` prop so that maintainers cannot edit section visibility (public/private), reflecting their restricted access. (`src/components/admin/forms/section-form.tsx`) [[1]](diffhunk://#diff-fcf8160b793078e709b21f5025e1754cb293229d427d02a6a2818ef9600e94bcR25-R35) [[2]](diffhunk://#diff-fcf8160b793078e709b21f5025e1754cb293229d427d02a6a2818ef9600e94bcR80)

**Maintainer Invitation Feature**

* Adds a new `MaintainerInviteDialog` component, allowing admins to send customized invitation emails to users to become maintainers of a course. (`src/components/admin/maintainer-invite-dialog.tsx`)
* Implements the mutation and schema for sending maintainer invites, including form validation for subject and body. (`src/lib/admin/mutations.ts`, `src/lib/admin/schemas.ts`) [[1]](diffhunk://#diff-f3e6cea2d089500c228ae9619711a06c21dcb0eec6ade0052feee25b3e115091R27) [[2]](diffhunk://#diff-f3e6cea2d089500c228ae9619711a06c21dcb0eec6ade0052feee25b3e115091R290-R297) [[3]](diffhunk://#diff-7cd92073abfe5b3f4a74426462b541019b399906801cab3db1d146475ce0d70aR227-R241)

**Backend Authorization Logic**

* Introduces new server-side access control utilities to enforce that only admins (not maintainers) can manage catalog structure (courses/classes), while maintainers are scoped to content management (sections/questions) for their assigned courses. (`src/lib/admin/server/access.ts`, `src/lib/admin/server/classes.ts`) [[1]](diffhunk://#diff-177c7b2c42d7a37f40d9f3c41f1714c40edb74927eb386a487d59a26c758ca2eR1-R108) [[2]](diffhunk://#diff-28aadc6186bb24040fb46c90ad4c13d02597df748f28411339ceba67bb046f42L56-R57) [[3]](diffhunk://#diff-28aadc6186bb24040fb46c90ad4c13d02597df748f28411339ceba67bb046f42L140-R141) [[4]](diffhunk://#diff-28aadc6186bb24040fb46c90ad4c13d02597df748f28411339ceba67bb046f42L170-R171)

**Notification and Query Enhancements**

* Adds a new notification type for `MAINTAINER_ASSIGNED` with its own icon. (`src/components/notifications/notification-item.tsx`) [[1]](diffhunk://#diff-9cb13f9c4d8771c6e4a86567afe651bc2629f0e23080f348cbbc75264bbfeb26R6) [[2]](diffhunk://#diff-9cb13f9c4d8771c6e4a86567afe651bc2629f0e23080f348cbbc75264bbfeb26R30)
* Adds a query to fetch the courses maintained by the current user, supporting the new role-based UI and features. (`src/lib/admin/queries.ts`) [[1]](diffhunk://#diff-6d4c06b1959a29efb2de0c77585daad2769d6175e8c990676c7418e344204673R14) [[2]](diffhunk://#diff-6d4c06b1959a29efb2de0c77585daad2769d6175e8c990676c7418e344204673R46-R52)

**Other UI and Type Improvements**

* Refines icon typing in the sidebar for improved type safety. (`src/components/admin/admin-sidebar.tsx`) [[1]](diffhunk://#diff-0d33194856a71c2a1202fcdda47be67ae38ac734922f0b3a1621aff685a49584R16-R20) [[2]](diffhunk://#diff-0d33194856a71c2a1202fcdda47be67ae38ac734922f0b3a1621aff685a49584L336-R357)

These changes collectively enhance security and user experience for admins and maintainers, ensuring that each role only accesses permitted features and data.