### PR TITLE
Admin: maintainer scoping, content-requests UX & role badge

### DIFF
--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -18,6 +18,7 @@ import {
 
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/hooks/useAuth"
+import { getRoleTheme } from "@/lib/admin/role-theme"
 import { adminQueries } from "@/lib/admin/queries"
 import { requestQueries } from "@/lib/requests/queries"
 import type {
@@ -28,6 +29,8 @@ import type {
 
 export function AdminSidebar() {
   const { user } = useAuth()
+  const theme = getRoleTheme(user?.role)
+  const RoleIcon = theme.icon
   const isSuperadmin = user?.role === "SUPERADMIN"
   const isMaintainer = user?.role === "MAINTAINER"
   const { data: stats } = useQuery(adminQueries.stats())
@@ -54,6 +57,18 @@ export function AdminSidebar() {
 
   return (
     <nav className="rounded-2xl border bg-card/50 p-4">
+      <div
+        className={cn(
+          "mb-3 flex items-center gap-2 rounded-xl border px-3 py-2",
+          theme.pillBorder,
+          theme.pillBg,
+        )}
+      >
+        <RoleIcon className={cn("h-4 w-4 shrink-0", theme.pillText)} strokeWidth={1.5} />
+        <span className={cn("text-xs font-bold uppercase tracking-wider", theme.pillText)}>
+          {theme.label}
+        </span>
+      </div>
       <p className="mb-2 px-3 text-xs font-semibold uppercase tracking-widest text-primary">
         Gestione
       </p>

--- a/src/components/admin/browse-admin-button.tsx
+++ b/src/components/admin/browse-admin-button.tsx
@@ -1,23 +1,36 @@
+import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { Settings } from "lucide-react"
 
 import { useAuth } from "@/hooks/useAuth"
+import { adminQueries } from "@/lib/admin/queries"
 import { Button } from "@/components/ui/button"
 
 type BrowseAdminButtonProps = {
   to: string
   params?: Record<string, string>
+  // A MAINTAINER sees the button only if this course is one they maintain;
+  // omit it (e.g. department page) to hide the button from maintainers.
+  courseId?: string
 }
 
-export function BrowseAdminButton({ to, params }: BrowseAdminButtonProps) {
+export function BrowseAdminButton({ to, params, courseId }: BrowseAdminButtonProps) {
   const { user } = useAuth()
+  const role = user?.role
+  const isFullAdmin = role === "SUPERADMIN" || role === "ADMIN"
+  const isMaintainer = role === "MAINTAINER"
 
-  const isAdmin =
-    user?.role === "SUPERADMIN" ||
-    user?.role === "ADMIN" ||
-    user?.role === "MAINTAINER"
+  const { data: permissions } = useQuery({
+    ...adminQueries.permissions(),
+    enabled: isMaintainer,
+  })
 
-  if (!isAdmin) return null
+  if (isMaintainer) {
+    if (!courseId) return null
+    if (!permissions?.maintainedCourseIds.includes(courseId)) return null
+  } else if (!isFullAdmin) {
+    return null
+  }
 
   return (
     <Button variant="outline" size="sm" className="rounded-xl" asChild>

--- a/src/components/requests/handle-request-dialog.tsx
+++ b/src/components/requests/handle-request-dialog.tsx
@@ -10,7 +10,21 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
+import { PresetReplies } from "@/components/requests/preset-replies"
 import { useHandleRequest } from "@/lib/requests/mutations"
+
+const NOTE_PRESETS: Record<"REJECTED" | "NEEDS_REVISION", string[]> = {
+  REJECTED: [
+    "Contenuto non in linea con le linee guida.",
+    "Contenuto già presente sulla piattaforma.",
+    "Le informazioni non sono corrette.",
+  ],
+  NEEDS_REVISION: [
+    "Aggiungi maggiori dettagli e reinvia.",
+    "Correggi la risposta corretta.",
+    "Rivedi la formattazione del contenuto.",
+  ],
+}
 
 const ACTIONS = [
   {
@@ -88,6 +102,12 @@ export function HandleRequestDialog({
               <label className="text-sm font-medium">
                 Nota per l&apos;utente
               </label>
+              <PresetReplies
+                presets={NOTE_PRESETS[selectedStatus]}
+                onPick={(text) =>
+                  setAdminNote((prev) => (prev ? `${prev} ${text}` : text))
+                }
+              />
               <Textarea
                 value={adminNote}
                 onChange={(e) => setAdminNote(e.target.value)}

--- a/src/components/requests/preset-replies.tsx
+++ b/src/components/requests/preset-replies.tsx
@@ -1,0 +1,24 @@
+type PresetRepliesProps = {
+  presets: string[]
+  onPick: (text: string) => void
+}
+
+// Quick-insert chips that append a canned reply to a note textarea.
+export function PresetReplies({ presets, onPick }: PresetRepliesProps) {
+  if (presets.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {presets.map((preset) => (
+        <button
+          key={preset}
+          type="button"
+          onClick={() => onPick(preset)}
+          className="rounded-full border bg-muted/40 px-3 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          {preset}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/lib/admin/role-theme.ts
+++ b/src/lib/admin/role-theme.ts
@@ -1,0 +1,44 @@
+import { Shield, ShieldCheck, ShieldHalf } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+
+// Role badge for the admin sidebar: a shield + role label whose colour signals
+// the privilege level. Classes are static so Tailwind picks them up; recolour a
+// role by editing only its entry below.
+export type RoleTheme = {
+  label: string
+  icon: LucideIcon
+  pillBg: string
+  pillText: string
+  pillBorder: string
+}
+
+const THEMES = {
+  SUPERADMIN: {
+    label: "Super Admin",
+    icon: ShieldCheck,
+    pillBg: "bg-violet-500/10",
+    pillText: "text-violet-600 dark:text-violet-400",
+    pillBorder: "border-violet-500/30",
+  },
+  ADMIN: {
+    label: "Admin",
+    icon: Shield,
+    pillBg: "bg-blue-500/10",
+    pillText: "text-blue-600 dark:text-blue-400",
+    pillBorder: "border-blue-500/30",
+  },
+  MAINTAINER: {
+    label: "Maintainer",
+    icon: ShieldHalf,
+    pillBg: "bg-emerald-500/10",
+    pillText: "text-emerald-600 dark:text-emerald-400",
+    pillBorder: "border-emerald-500/30",
+  },
+} satisfies Record<string, RoleTheme>
+
+export function getRoleTheme(role: string | undefined): RoleTheme {
+  if (role === "SUPERADMIN" || role === "ADMIN" || role === "MAINTAINER") {
+    return THEMES[role]
+  }
+  return THEMES.ADMIN
+}

--- a/src/lib/admin/server/access.ts
+++ b/src/lib/admin/server/access.ts
@@ -1,3 +1,5 @@
+import { redirect } from "@tanstack/react-router"
+
 import { requireAdmin } from "@/lib/auth/guards"
 import { getCatalogAdmin } from "@/lib/supabase/admin"
 import type { AuthUser } from "@/lib/auth/types"
@@ -5,8 +7,9 @@ import type { AuthUser } from "@/lib/auth/types"
 // ─── Content authorization ───
 //
 // Role model for the admin catalog:
-//   • Courses + classes (the structural catalog) are managed by ADMIN and
-//     SUPERADMIN. Maintainers are content-only and are rejected for these.
+//   • Departments + courses + classes (the structural catalog) are managed by
+//     ADMIN and SUPERADMIN. Maintainers are content-only and are rejected for
+//     these, and are redirected away from the corresponding admin pages.
 //   • Sections + questions are managed by ADMIN, SUPERADMIN and MAINTAINER.
 //     For a MAINTAINER, access is scoped: the owning class must belong to at
 //     least one course they maintain (a class can be shared across courses).
@@ -14,16 +17,16 @@ import type { AuthUser } from "@/lib/auth/types"
 // ADMIN/SUPERADMIN remain unscoped (unchanged behavior). All resolution uses
 // the service-role catalog client since this is server-side authorization.
 
-// Structural catalog (courses + classes) — ADMIN+ only.
+// Structural catalog (departments + courses + classes) — ADMIN+ only.
 export async function requireStructureManager(): Promise<AuthUser> {
   const user = await requireAdmin()
   if (user.role === "MAINTAINER") {
-    throw new Error("I maintainer non possono modificare corsi o insegnamenti.")
+    throw new Error("I maintainer non possono modificare la struttura del catalogo.")
   }
   return user
 }
 
-async function maintainedCourseIds(userId: string): Promise<Set<string>> {
+export async function maintainedCourseIds(userId: string): Promise<Set<string>> {
   const { data } = await getCatalogAdmin()
     .from("course_maintainers")
     .select("course_id")
@@ -31,21 +34,25 @@ async function maintainedCourseIds(userId: string): Promise<Set<string>> {
   return new Set((data ?? []).map((r) => r.course_id))
 }
 
-// No-op for ADMIN/SUPERADMIN; for a MAINTAINER, requires that the class belongs
-// to at least one course they maintain.
-async function assertClassScope(user: AuthUser, classId: string): Promise<void> {
-  if (user.role !== "MAINTAINER") return
-
+async function classInMaintainedScope(
+  userId: string,
+  classId: string,
+): Promise<boolean> {
   const [{ data: links }, maintained] = await Promise.all([
     getCatalogAdmin()
       .from("course_classes")
       .select("course_id")
       .eq("class_id", classId),
-    maintainedCourseIds(user.id),
+    maintainedCourseIds(userId),
   ])
+  return (links ?? []).some((l) => maintained.has(l.course_id))
+}
 
-  const inScope = (links ?? []).some((l) => maintained.has(l.course_id))
-  if (!inScope) {
+// No-op for ADMIN/SUPERADMIN; for a MAINTAINER, requires that the class belongs
+// to at least one course they maintain.
+async function assertClassScope(user: AuthUser, classId: string): Promise<void> {
+  if (user.role !== "MAINTAINER") return
+  if (!(await classInMaintainedScope(user.id, classId))) {
     throw new Error(
       "Non hai i permessi per gestire i contenuti di questo insegnamento.",
     )
@@ -104,5 +111,79 @@ export async function requireContentManagerForQuestion(
   if (error || !data) throw new Error("Domanda non trovata")
 
   await assertSectionScope(user, data.section_id)
+  return user
+}
+
+// ─── Read-access guards for admin detail pages ───
+//
+// A MAINTAINER who opens a page outside the courses they maintain is redirected
+// back to the dashboard; departments are off-limits to maintainers entirely.
+
+async function sectionInMaintainedScope(
+  userId: string,
+  sectionId: string,
+): Promise<boolean> {
+  const { data } = await getCatalogAdmin()
+    .from("sections")
+    .select("class_id, is_public")
+    .eq("id", sectionId)
+    .single()
+  if (!data || !data.is_public) return false
+  return classInMaintainedScope(userId, data.class_id)
+}
+
+export async function requireDepartmentAccess(): Promise<AuthUser> {
+  const user = await requireAdmin()
+  if (user.role === "MAINTAINER") throw redirect({ to: "/admin" })
+  return user
+}
+
+export async function requireCourseAccess(courseId: string): Promise<AuthUser> {
+  const user = await requireAdmin()
+  if (user.role === "MAINTAINER") {
+    const maintained = await maintainedCourseIds(user.id)
+    if (!maintained.has(courseId)) throw redirect({ to: "/admin" })
+  }
+  return user
+}
+
+export async function requireClassAccess(classId: string): Promise<AuthUser> {
+  const user = await requireAdmin()
+  if (
+    user.role === "MAINTAINER" &&
+    !(await classInMaintainedScope(user.id, classId))
+  ) {
+    throw redirect({ to: "/admin" })
+  }
+  return user
+}
+
+export async function requireSectionAccess(
+  sectionId: string,
+): Promise<AuthUser> {
+  const user = await requireAdmin()
+  if (
+    user.role === "MAINTAINER" &&
+    !(await sectionInMaintainedScope(user.id, sectionId))
+  ) {
+    throw redirect({ to: "/admin" })
+  }
+  return user
+}
+
+export async function requireQuestionAccess(
+  questionId: string,
+): Promise<AuthUser> {
+  const user = await requireAdmin()
+  if (user.role !== "MAINTAINER") return user
+
+  const { data } = await getCatalogAdmin()
+    .from("questions")
+    .select("section_id")
+    .eq("id", questionId)
+    .single()
+  if (!data || !(await sectionInMaintainedScope(user.id, data.section_id))) {
+    throw redirect({ to: "/admin" })
+  }
   return user
 }

--- a/src/lib/admin/server/classes.ts
+++ b/src/lib/admin/server/classes.ts
@@ -1,9 +1,8 @@
 import { createServerFn } from "@tanstack/react-start"
 
-import { requireAdmin } from "@/lib/auth/guards"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
-import { requireStructureManager } from "./access"
+import { requireClassAccess, requireStructureManager } from "./access"
 import {
   classSchema,
   courseClassSchema,
@@ -17,7 +16,7 @@ import {
 export const getAdminClassDetailFn = createServerFn({ method: "GET" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireClassAccess(id)
     const supabase = createServerSupabaseClient()
 
     const { data: cls, error: clsError } = await catalogQuery(supabase)

--- a/src/lib/admin/server/courses.ts
+++ b/src/lib/admin/server/courses.ts
@@ -1,9 +1,8 @@
 import { createServerFn } from "@tanstack/react-start"
 
-import { requireAdmin } from "@/lib/auth/guards"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
-import { requireStructureManager } from "./access"
+import { requireCourseAccess, requireStructureManager } from "./access"
 import { courseSchema, idSchema, updateCourseSchema } from "../schemas"
 
 // ─── Courses ───
@@ -11,7 +10,7 @@ import { courseSchema, idSchema, updateCourseSchema } from "../schemas"
 export const getAdminCourseDetailFn = createServerFn({ method: "GET" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireCourseAccess(id)
     const supabase = createServerSupabaseClient()
 
     const { data: course, error: courseError } = await catalogQuery(supabase)

--- a/src/lib/admin/server/departments.ts
+++ b/src/lib/admin/server/departments.ts
@@ -1,8 +1,8 @@
 import { createServerFn } from "@tanstack/react-start"
 
-import { requireAdmin } from "@/lib/auth/guards"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
+import { requireDepartmentAccess, requireStructureManager } from "./access"
 import {
   departmentSchema,
   idSchema,
@@ -15,7 +15,7 @@ import type { AdminCourse, AdminDepartment } from "../types"
 export const getAdminDepartmentsFn = createServerFn({
   method: "GET",
 }).handler(async (): Promise<AdminDepartment[]> => {
-  await requireAdmin()
+  await requireDepartmentAccess()
   const supabase = createServerSupabaseClient()
 
   const { data, error } = await catalogQuery(supabase)
@@ -30,7 +30,7 @@ export const getAdminDepartmentsFn = createServerFn({
 export const getAdminDepartmentDetailFn = createServerFn({ method: "GET" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireDepartmentAccess()
     const supabase = createServerSupabaseClient()
 
     const { data: department, error: deptError } = await catalogQuery(supabase)
@@ -60,7 +60,7 @@ export const getAdminDepartmentDetailFn = createServerFn({ method: "GET" })
 export const createDepartmentFn = createServerFn({ method: "POST" })
   .inputValidator(departmentSchema)
   .handler(async ({ data }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     // Get next position
@@ -93,7 +93,7 @@ export const createDepartmentFn = createServerFn({ method: "POST" })
 export const updateDepartmentFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema.merge(updateDepartmentSchema))
   .handler(async ({ data: { id, ...updates } }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     const updateData: Record<string, unknown> = {}
@@ -124,7 +124,7 @@ export const updateDepartmentFn = createServerFn({ method: "POST" })
 export const deleteDepartmentFn = createServerFn({ method: "POST" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireStructureManager()
     const supabase = createServerSupabaseClient()
 
     // Check for child courses

--- a/src/lib/admin/server/questions.ts
+++ b/src/lib/admin/server/questions.ts
@@ -8,6 +8,7 @@ import {
   assertSectionScope,
   requireContentManagerForQuestion,
   requireContentManagerForSection,
+  requireQuestionAccess,
 } from "./access"
 import { idSchema, questionSchema, updateQuestionSchema } from "../schemas"
 
@@ -16,7 +17,7 @@ import { idSchema, questionSchema, updateQuestionSchema } from "../schemas"
 export const getAdminQuestionDetailFn = createServerFn({ method: "GET" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireQuestionAccess(id)
     const supabase = createServerSupabaseClient()
 
     const { data: question, error } = await catalogQuery(supabase)

--- a/src/lib/admin/server/sections.ts
+++ b/src/lib/admin/server/sections.ts
@@ -1,11 +1,11 @@
 import { createServerFn } from "@tanstack/react-start"
 
-import { requireAdmin } from "@/lib/auth/guards"
 import { catalogQuery, createServerSupabaseClient } from "@/lib/supabase/server"
 
 import {
   requireContentManagerForClass,
   requireContentManagerForSection,
+  requireSectionAccess,
 } from "./access"
 import { idSchema, sectionSchema, updateSectionSchema } from "../schemas"
 
@@ -14,7 +14,7 @@ import { idSchema, sectionSchema, updateSectionSchema } from "../schemas"
 export const getAdminSectionDetailFn = createServerFn({ method: "GET" })
   .inputValidator(idSchema)
   .handler(async ({ data: { id } }) => {
-    await requireAdmin()
+    await requireSectionAccess(id)
     const supabase = createServerSupabaseClient()
 
     const { data: section, error: secError } = await catalogQuery(supabase)

--- a/src/lib/requests/mutations.ts
+++ b/src/lib/requests/mutations.ts
@@ -4,8 +4,10 @@ import {
   acknowledgeRequestFn,
   approveRequestFn,
   createRequestFn,
+  deleteReportFn,
   handleRequestFn,
   reviseRequestFn,
+  updateReportFn,
 } from "./server"
 
 // ─── User Mutations ───
@@ -32,6 +34,32 @@ export function useReviseRequest(onSuccess?: () => void) {
       ["requests", "detail"],
       ["admin", "requests"],
       ["admin", "requestCount"],
+    ],
+    onSuccess,
+  })
+}
+
+export function useUpdateReport(onSuccess?: () => void) {
+  return useMutationWithToast(updateReportFn, {
+    successMessage: "Segnalazione aggiornata",
+    invalidateKeys: [
+      ["requests", "mine"],
+      ["admin", "requests"],
+      ["admin", "requestCount"],
+    ],
+    onSuccess,
+  })
+}
+
+export function useDeleteReport(onSuccess?: () => void) {
+  return useMutationWithToast(deleteReportFn, {
+    successMessage: "Segnalazione eliminata",
+    invalidateKeys: [
+      ["requests", "mine"],
+      ["admin", "requests"],
+      ["admin", "requestCount"],
+      ["notifications"],
+      ["notifications", "unreadCount"],
     ],
     onSuccess,
   })

--- a/src/lib/requests/server.ts
+++ b/src/lib/requests/server.ts
@@ -348,11 +348,17 @@ export const getAdminRequestsFn = createServerFn({ method: "GET" }).handler(
       isInScope(scopeCourseIds, r.target_course_id),
     )
 
-    const userIds = [...new Set(rows.map((r) => r.user_id))]
+    const profileIds = [
+      ...new Set(
+        rows
+          .flatMap((r) => [r.user_id, r.handled_by])
+          .filter((v): v is string => !!v),
+      ),
+    ]
     const { data: profiles } = await getSupabaseAdmin()
       .from("profiles")
       .select("id, name, email, image")
-      .in("id", userIds.length > 0 ? userIds : ["__none__"])
+      .in("id", profileIds.length > 0 ? profileIds : ["__none__"])
 
     const profileMap = new Map((profiles ?? []).map((p) => [p.id, p]))
 
@@ -370,6 +376,9 @@ export const getAdminRequestsFn = createServerFn({ method: "GET" }).handler(
           email: null,
           image: null,
         },
+        handledBy: req.handled_by
+          ? profileMap.get(req.handled_by) ?? null
+          : null,
       })
     }
 
@@ -413,24 +422,32 @@ export const getRequestDetailFn = createServerFn({ method: "GET" })
     if (error || !request) throw new Error("Proposta non trovata")
 
     // Owner views their own request; everyone else needs admin access (and a
-    // maintainer must be in scope). Admin viewers also get the author profile.
+    // maintainer must be in scope). Admin viewers also get the author profile
+    // and, when handled, the profile of the admin who handled it.
     let author: RequestUser | null = null
+    let handledBy: RequestUser | null = null
     if (request.user_id !== user.id) {
       const { scopeCourseIds } = await requireRequestAdmin()
       if (!isInScope(scopeCourseIds, request.target_course_id)) {
         throw redirect({ to: "/admin/requests" })
       }
-      const { data: profile } = await getSupabaseAdmin()
+      const ids = [request.user_id, request.handled_by].filter(
+        (v): v is string => !!v,
+      )
+      const { data: profiles } = await getSupabaseAdmin()
         .from("profiles")
         .select("id, name, email, image")
-        .eq("id", request.user_id)
-        .single()
-      author = profile ?? {
+        .in("id", ids)
+      const byId = new Map((profiles ?? []).map((p) => [p.id, p]))
+      author = byId.get(request.user_id) ?? {
         id: request.user_id,
         name: null,
         email: null,
         image: null,
       }
+      handledBy = request.handled_by
+        ? byId.get(request.handled_by) ?? null
+        : null
     }
 
     const target_label = await buildTargetLabel(supabase, request)
@@ -446,7 +463,14 @@ export const getRequestDetailFn = createServerFn({ method: "GET" })
       if (question) reported_question = question as ReportedQuestion
     }
 
-    return { ...request, target_label, submitted, reported_question, user: author }
+    return {
+      ...request,
+      target_label,
+      submitted,
+      reported_question,
+      user: author,
+      handledBy,
+    }
   })
 
 // ─── Admin Mutations ───

--- a/src/lib/requests/server.ts
+++ b/src/lib/requests/server.ts
@@ -1,12 +1,41 @@
 import { createServerFn } from "@tanstack/react-start"
+import { redirect } from "@tanstack/react-router"
 
 import { requireAdmin } from "@/lib/auth/guards"
+import { maintainedCourseIds } from "@/lib/admin/server/access"
 import { createNotification, notifyAdminsInScope } from "@/lib/notifications/helpers"
 import { getSupabaseAdmin, getCatalogAdmin } from "@/lib/supabase/admin"
 import { createServerSupabaseClient, catalogQuery } from "@/lib/supabase/server"
+import type { AuthUser } from "@/lib/auth/types"
 
 import { storedContentSchema } from "./schemas"
-import type { AdminContentRequest, ContentRequestWithMeta, ReportedQuestion, SubmittedContent } from "./types"
+import type {
+  AdminContentRequest,
+  ContentRequestDetail,
+  ContentRequestWithMeta,
+  ReportedQuestion,
+  RequestUser,
+  SubmittedContent,
+} from "./types"
+
+// Admin guard for the requests area. Maintainers only see requests targeting a
+// course they maintain; ADMIN/SUPERADMIN are unscoped (scopeCourseIds = null).
+async function requireRequestAdmin(): Promise<{
+  user: AuthUser
+  scopeCourseIds: Set<string> | null
+}> {
+  const user = await requireAdmin()
+  if (user.role !== "MAINTAINER") return { user, scopeCourseIds: null }
+  return { user, scopeCourseIds: await maintainedCourseIds(user.id) }
+}
+
+function isInScope(
+  scopeCourseIds: Set<string> | null,
+  targetCourseId: string | null,
+): boolean {
+  if (!scopeCourseIds) return true
+  return !!targetCourseId && scopeCourseIds.has(targetCourseId)
+}
 
 /** Validate JSONB content from DB against Zod schema at runtime */
 function parseSubmittedContent(raw: unknown): SubmittedContent {
@@ -305,7 +334,7 @@ export const reviseRequestFn = createServerFn({ method: "POST" })
 
 export const getAdminRequestsFn = createServerFn({ method: "GET" }).handler(
   async (): Promise<AdminContentRequest[]> => {
-    await requireAdmin()
+    const { scopeCourseIds } = await requireRequestAdmin()
     const supabase = createServerSupabaseClient()
 
     const { data, error } = await supabase
@@ -315,7 +344,11 @@ export const getAdminRequestsFn = createServerFn({ method: "GET" }).handler(
 
     if (error) throw new Error("Errore nel caricamento delle proposte")
 
-    const userIds = [...new Set((data ?? []).map((r) => r.user_id))]
+    const rows = (data ?? []).filter((r) =>
+      isInScope(scopeCourseIds, r.target_course_id),
+    )
+
+    const userIds = [...new Set(rows.map((r) => r.user_id))]
     const { data: profiles } = await getSupabaseAdmin()
       .from("profiles")
       .select("id, name, email, image")
@@ -324,7 +357,7 @@ export const getAdminRequestsFn = createServerFn({ method: "GET" }).handler(
     const profileMap = new Map((profiles ?? []).map((p) => [p.id, p]))
 
     const requests: AdminContentRequest[] = []
-    for (const req of data ?? []) {
+    for (const req of rows) {
       const target_label = await buildTargetLabel(supabase, req)
       const submitted = parseSubmittedContent(req.submitted_content)
       requests.push({
@@ -347,21 +380,28 @@ export const getAdminRequestsFn = createServerFn({ method: "GET" }).handler(
 export const getAdminRequestCountFn = createServerFn({
   method: "GET",
 }).handler(async (): Promise<number> => {
-  await requireAdmin()
+  const { scopeCourseIds } = await requireRequestAdmin()
   const supabase = createServerSupabaseClient()
 
-  const { count, error } = await supabase
+  if (scopeCourseIds && scopeCourseIds.size === 0) return 0
+
+  let query = supabase
     .from("content_requests")
     .select("*", { count: "exact", head: true })
     .eq("status", "PENDING")
 
+  if (scopeCourseIds) {
+    query = query.in("target_course_id", [...scopeCourseIds])
+  }
+
+  const { count, error } = await query
   if (error) throw new Error("Errore nel conteggio delle proposte")
   return count ?? 0
 })
 
 export const getRequestDetailFn = createServerFn({ method: "GET" })
   .inputValidator((input: { id: string }) => input)
-  .handler(async ({ data: { id } }): Promise<ContentRequestWithMeta> => {
+  .handler(async ({ data: { id } }): Promise<ContentRequestDetail> => {
     const { supabase, user } = await getAuthUser()
 
     const { data: request, error } = await supabase
@@ -372,9 +412,25 @@ export const getRequestDetailFn = createServerFn({ method: "GET" })
 
     if (error || !request) throw new Error("Proposta non trovata")
 
-    // Verify ownership or admin access
+    // Owner views their own request; everyone else needs admin access (and a
+    // maintainer must be in scope). Admin viewers also get the author profile.
+    let author: RequestUser | null = null
     if (request.user_id !== user.id) {
-      await requireAdmin()
+      const { scopeCourseIds } = await requireRequestAdmin()
+      if (!isInScope(scopeCourseIds, request.target_course_id)) {
+        throw redirect({ to: "/admin/requests" })
+      }
+      const { data: profile } = await getSupabaseAdmin()
+        .from("profiles")
+        .select("id, name, email, image")
+        .eq("id", request.user_id)
+        .single()
+      author = profile ?? {
+        id: request.user_id,
+        name: null,
+        email: null,
+        image: null,
+      }
     }
 
     const target_label = await buildTargetLabel(supabase, request)
@@ -390,7 +446,7 @@ export const getRequestDetailFn = createServerFn({ method: "GET" })
       if (question) reported_question = question as ReportedQuestion
     }
 
-    return { ...request, target_label, submitted, reported_question }
+    return { ...request, target_label, submitted, reported_question, user: author }
   })
 
 // ─── Admin Mutations ───
@@ -404,16 +460,19 @@ export const handleRequestFn = createServerFn({ method: "POST" })
     }) => input,
   )
   .handler(async ({ data }) => {
-    const admin = await requireAdmin()
+    const { user: admin, scopeCourseIds } = await requireRequestAdmin()
     const supabase = createServerSupabaseClient()
 
     const { data: request, error: fetchError } = await supabase
       .from("content_requests")
-      .select("user_id")
+      .select("user_id, target_course_id")
       .eq("id", data.id)
       .single()
 
     if (fetchError || !request) throw new Error("Proposta non trovata")
+    if (!isInScope(scopeCourseIds, request.target_course_id)) {
+      throw new Error("Non hai i permessi per gestire questa richiesta.")
+    }
 
     const { error } = await supabase
       .from("content_requests")
@@ -450,8 +509,19 @@ export const handleRequestFn = createServerFn({ method: "POST" })
 export const approveRequestFn = createServerFn({ method: "POST" })
   .inputValidator((input: { id: string }) => input)
   .handler(async ({ data }) => {
-    const admin = await requireAdmin()
+    const { user: admin, scopeCourseIds } = await requireRequestAdmin()
     const supabase = createServerSupabaseClient()
+
+    if (scopeCourseIds) {
+      const { data: target } = await supabase
+        .from("content_requests")
+        .select("target_course_id")
+        .eq("id", data.id)
+        .single()
+      if (!target || !isInScope(scopeCourseIds, target.target_course_id)) {
+        throw new Error("Non hai i permessi per gestire questa richiesta.")
+      }
+    }
 
     // Atomic claim: transition PENDING → APPROVED in a single statement so
     // concurrent clicks cannot both proceed to insert catalog content.
@@ -548,16 +618,19 @@ export const approveRequestFn = createServerFn({ method: "POST" })
 export const acknowledgeRequestFn = createServerFn({ method: "POST" })
   .inputValidator((input: { id: string; admin_note?: string }) => input)
   .handler(async ({ data }) => {
-    const admin = await requireAdmin()
+    const { user: admin, scopeCourseIds } = await requireRequestAdmin()
     const supabase = createServerSupabaseClient()
 
     const { data: request, error: fetchError } = await supabase
       .from("content_requests")
-      .select("user_id, request_type")
+      .select("user_id, request_type, target_course_id")
       .eq("id", data.id)
       .single()
 
     if (fetchError || !request) throw new Error("Proposta non trovata")
+    if (!isInScope(scopeCourseIds, request.target_course_id)) {
+      throw new Error("Non hai i permessi per gestire questa richiesta.")
+    }
 
     const { error } = await supabase
       .from("content_requests")

--- a/src/lib/requests/server.ts
+++ b/src/lib/requests/server.ts
@@ -293,20 +293,26 @@ export const reviseRequestFn = createServerFn({ method: "POST" })
     (input: { id: string; submitted_content: unknown }) => input,
   )
   .handler(async ({ data }) => {
-    const { supabase, user } = await getAuthUser()
+    const { user } = await getAuthUser()
+    const admin = getSupabaseAdmin()
 
-    const { data: existing, error: fetchError } = await supabase
+    // Validate the resubmitted content before touching the row.
+    const submitted = parseSubmittedContent(data.submitted_content)
+
+    const { data: existing, error: fetchError } = await admin
       .from("content_requests")
-      .select("*")
+      .select("user_id, status, handled_by")
       .eq("id", data.id)
-      .eq("user_id", user.id)
-      .eq("status", "NEEDS_REVISION")
       .single()
 
-    if (fetchError || !existing)
-      throw new Error("Proposta non trovata o non modificabile")
+    if (fetchError || !existing) throw new Error("Proposta non trovata")
+    if (existing.user_id !== user.id) throw new Error("Non autorizzato")
+    if (existing.status !== "NEEDS_REVISION")
+      throw new Error("La proposta non è modificabile")
 
-    const { error } = await supabase
+    // RLS only grants UPDATE to admins, so use the service-role client after
+    // verifying ownership + status here.
+    const { error } = await admin
       .from("content_requests")
       .update({
         status: "PENDING" as const,
@@ -318,16 +324,100 @@ export const reviseRequestFn = createServerFn({ method: "POST" })
     if (error) throw new Error("Errore nell'aggiornamento della proposta")
 
     if (existing.handled_by) {
-      await createNotification(getSupabaseAdmin(), {
+      await createNotification(admin, {
         userId: existing.handled_by,
         type: "REQUEST_REVISED",
         title: "Proposta aggiornata",
-        body: generateTitle(parseSubmittedContent(data.submitted_content)),
+        body: generateTitle(submitted),
         referenceId: data.id,
         referenceType: "content_request",
         link: `/admin/requests/${data.id}`,
       })
     }
+  })
+
+const REPORT_REASONS = ["errata", "imprecisa", "fuori_contesto", "altro"]
+
+// Edit own report while it is still pending (not yet handled). Uses the
+// service-role client after verifying ownership + status, since RLS only
+// grants UPDATE to admins.
+export const updateReportFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (input: { id: string; reasons: string[]; comment: string | null }) => input,
+  )
+  .handler(async ({ data }) => {
+    const { user } = await getAuthUser()
+    const admin = getSupabaseAdmin()
+
+    const { data: request, error } = await admin
+      .from("content_requests")
+      .select("user_id, status, request_type, submitted_content")
+      .eq("id", data.id)
+      .single()
+
+    if (error || !request) throw new Error("Segnalazione non trovata")
+    if (request.user_id !== user.id) throw new Error("Non autorizzato")
+    if (request.request_type !== "REPORT")
+      throw new Error("Solo le segnalazioni possono essere modificate qui")
+    if (request.status !== "PENDING")
+      throw new Error("La segnalazione è già stata gestita e non può essere modificata")
+
+    if (
+      data.reasons.length === 0 ||
+      !data.reasons.every((r) => REPORT_REASONS.includes(r))
+    ) {
+      throw new Error("Seleziona almeno un motivo valido")
+    }
+    const comment = data.comment?.trim() || null
+    if (data.reasons.includes("altro") && !comment) {
+      throw new Error("Il commento è obbligatorio quando selezioni 'Altro'")
+    }
+
+    const existing = parseSubmittedContent(request.submitted_content)
+    if (existing.type !== "report") throw new Error("Tipo di richiesta non valido")
+
+    const updated = { ...existing, reasons: data.reasons, comment }
+    const { error: updateError } = await admin
+      .from("content_requests")
+      .update({ submitted_content: JSON.parse(JSON.stringify(updated)) })
+      .eq("id", data.id)
+
+    if (updateError) throw new Error("Errore nell'aggiornamento della segnalazione")
+  })
+
+// Delete own report while it is still pending. Also clears the admin
+// notifications that pointed to it.
+export const deleteReportFn = createServerFn({ method: "POST" })
+  .inputValidator((input: { id: string }) => input)
+  .handler(async ({ data }) => {
+    const { user } = await getAuthUser()
+    const admin = getSupabaseAdmin()
+
+    const { data: request, error } = await admin
+      .from("content_requests")
+      .select("user_id, status, request_type")
+      .eq("id", data.id)
+      .single()
+
+    if (error || !request) throw new Error("Segnalazione non trovata")
+    if (request.user_id !== user.id) throw new Error("Non autorizzato")
+    if (request.request_type !== "REPORT")
+      throw new Error("Solo le segnalazioni possono essere eliminate qui")
+    if (request.status !== "PENDING")
+      throw new Error("La segnalazione è già stata gestita e non può essere eliminata")
+
+    await admin
+      .from("notifications")
+      .delete()
+      .eq("reference_id", data.id)
+      .eq("reference_type", "content_request")
+
+    const { error: deleteError } = await admin
+      .from("content_requests")
+      .delete()
+      .eq("id", data.id)
+
+    if (deleteError) throw new Error("Errore nell'eliminazione della segnalazione")
   })
 
 // ─── Admin Queries ───

--- a/src/lib/requests/types.ts
+++ b/src/lib/requests/types.ts
@@ -60,12 +60,19 @@ export type ContentRequestWithMeta = ContentRequest & {
   reported_question?: ReportedQuestion | null
 }
 
-// Admin view includes user info
+export type RequestUser = {
+  id: string
+  name: string | null
+  email: string | null
+  image: string | null
+}
+
+// Admin list view includes the author's profile
 export type AdminContentRequest = ContentRequestWithMeta & {
-  user: {
-    id: string
-    name: string | null
-    email: string | null
-    image: string | null
-  }
+  user: RequestUser
+}
+
+// Admin detail view: user is null when the owner views their own request
+export type ContentRequestDetail = ContentRequestWithMeta & {
+  user: RequestUser | null
 }

--- a/src/lib/requests/types.ts
+++ b/src/lib/requests/types.ts
@@ -67,12 +67,16 @@ export type RequestUser = {
   image: string | null
 }
 
-// Admin list view includes the author's profile
+// Admin list view includes the author's profile and, when handled, the
+// profile of the admin who handled it
 export type AdminContentRequest = ContentRequestWithMeta & {
   user: RequestUser
+  handledBy: RequestUser | null
 }
 
-// Admin detail view: user is null when the owner views their own request
+// Admin detail view: user/handledBy are null when the owner views their own
+// request; handledBy is also null until the request has been handled
 export type ContentRequestDetail = ContentRequestWithMeta & {
   user: RequestUser | null
+  handledBy: RequestUser | null
 }

--- a/src/routes/_app/admin/requests/$requestId.tsx
+++ b/src/routes/_app/admin/requests/$requestId.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react"
+import { useState, type ReactNode } from "react"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { seoHead } from "@/lib/seo"
-import { ArrowLeft, CheckCircle2, ChevronDown, Download, Eye, FileUp, MapPin, Pencil, Settings2, UserCog } from "lucide-react"
+import { CheckCircle2, ChevronDown, Clock, Download, Eye, FileUp, Pencil, Settings2, UserCog } from "lucide-react"
 
 import { AdminPageHeader } from "@/components/admin/admin-page-header"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { HandleRequestDialog } from "@/components/requests/handle-request-dialog"
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer"
+import { PresetReplies } from "@/components/requests/preset-replies"
 import { RequestStatusBadge } from "@/components/requests/request-status-badge"
 import { RequestTypeBadge } from "@/components/requests/request-type-badge"
 import { Textarea } from "@/components/ui/textarea"
@@ -24,12 +25,40 @@ import { toast } from "sonner"
 
 import type { ReportedQuestion, SubmittedContent, SubmittedFileUpload, SubmittedQuestion } from "@/lib/requests/types"
 
+const REASON_LABELS: Record<string, string> = {
+  errata: "Errata",
+  imprecisa: "Imprecisa",
+  fuori_contesto: "Fuori contesto",
+  altro: "Altro",
+}
+
+const ACK_PRESETS = [
+  "Grazie della segnalazione, abbiamo verificato.",
+  "Grazie della segnalazione, abbiamo corretto la domanda.",
+  "Grazie del contributo!",
+]
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso)
+  const sameYear = d.getFullYear() === new Date().getFullYear()
+  const date = d.toLocaleDateString("it-IT", {
+    day: "numeric",
+    month: "short",
+    ...(sameYear ? {} : { year: "numeric" }),
+  })
+  const time = d.toLocaleTimeString("it-IT", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+  return `${date}, ${time}`
+}
+
 export const Route = createFileRoute("/_app/admin/requests/$requestId")({
   loader: ({ context, params }) =>
     context.queryClient.ensureQueryData(
       requestQueries.requestDetail(params.requestId),
     ),
-  head: () => seoHead({ title: "Dettaglio Proposta", noindex: true }),
+  head: () => seoHead({ title: "Dettaglio Richiesta", noindex: true }),
   component: AdminRequestDetailPage,
 })
 
@@ -50,92 +79,92 @@ function AdminRequestDetailPage() {
   const isFileUpload = request.request_type === "FILE_UPLOAD"
   const isAcknowledgeOnly = isReport || isFileUpload
 
+  const submitted = request.submitted
+  // The user's words (reasons + free-text) are kept separate from the material
+  // under review so reviewers can tell them apart at a glance.
+  const reasons = submitted.type === "report" ? submitted.reasons : []
+  const userComment =
+    submitted.type === "report" || submitted.type === "file_upload"
+      ? submitted.comment
+      : null
+  const reportedQuestionId =
+    submitted.type === "report" ? submitted.question_id : null
+  const hasUserMessage = reasons.length > 0 || !!userComment
+
+  const materialLabel = isReport
+    ? "Domanda segnalata"
+    : isFileUpload
+      ? "File caricato"
+      : "Contenuto proposto"
+
   return (
-    <div className="space-y-6">
-      <AdminPageHeader title="Dettaglio Proposta" description="" />
+    <div className="space-y-6 py-2">
+      <AdminPageHeader
+        title="Dettaglio richiesta"
+        description={request.target_label}
+        backTo="/admin/requests"
+        backLabel="Richieste"
+        actions={
+          isPending && !isAcknowledgeOnly ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 rounded-xl"
+                onClick={() => setHandleOpen(true)}
+              >
+                <Settings2 className="size-4" />
+                Rifiuta / Modifiche
+              </Button>
+              <Button
+                size="sm"
+                className="gap-1.5 rounded-xl bg-green-600 hover:bg-green-700"
+                onClick={() => approve.mutate({ id: request.id })}
+                disabled={approve.isPending}
+              >
+                <CheckCircle2 className="size-4" />
+                {approve.isPending ? "Approvazione..." : "Approva e pubblica"}
+              </Button>
+            </>
+          ) : undefined
+        }
+      />
 
-      {/* Back + Actions */}
-      <div className="flex items-center justify-between">
-        <Button asChild variant="ghost" size="sm" className="gap-1 rounded-xl">
-          <Link to="/admin/requests">
-            <ArrowLeft className="size-4" />
-            Torna alle proposte
-          </Link>
-        </Button>
-
-        {isPending && !isAcknowledgeOnly && (
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              className="gap-1.5 rounded-xl"
-              onClick={() => setHandleOpen(true)}
-            >
-              <Settings2 className="size-4" />
-              Rifiuta / Modifiche
-            </Button>
-            <Button
-              size="sm"
-              className="gap-1.5 rounded-xl bg-green-600 hover:bg-green-700"
-              onClick={() => approve.mutate({ id: request.id })}
-              disabled={approve.isPending}
-            >
-              <CheckCircle2 className="size-4" />
-              {approve.isPending ? "Approvazione..." : "Approva e pubblica"}
-            </Button>
+      {/* Summary: type + outcome, then who sent it and when */}
+      <div className="space-y-4 rounded-2xl border bg-card p-6">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <RequestTypeBadge type={request.request_type} />
+            <RequestStatusBadge status={request.status} />
           </div>
-        )}
-      </div>
-
-      {/* Request info */}
-      <div className="rounded-2xl border bg-card p-6 space-y-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <RequestTypeBadge type={request.request_type} />
-          <RequestStatusBadge status={request.status} />
-        </div>
-
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <MapPin className="size-4 shrink-0" strokeWidth={1.5} />
-          {request.target_label}
-        </div>
-
-        <p className="text-xs text-muted-foreground">
-          Inviata il{" "}
-          {new Date(request.created_at).toLocaleDateString("it-IT", {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
-        </p>
-
-        {request.admin_note && (
-          <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4">
-            <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
-              Nota amministratore
+          {request.handled_at && (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <CheckCircle2 className="size-3.5 shrink-0" strokeWidth={1.5} />
+              <span>
+                Gestita da{" "}
+                <span className="font-medium text-foreground">
+                  {request.handledBy?.name ?? "Team"}
+                </span>{" "}
+                · {formatDateTime(request.handled_at)}
+              </span>
             </p>
-            <p className="mt-1 text-sm">{request.admin_note}</p>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
 
-      {/* Author */}
-      {request.user && (
-        <div className="rounded-2xl border bg-card p-6">
-          <h3 className="mb-4 text-sm font-semibold uppercase tracking-widest text-primary">
-            Inviata da
-          </h3>
-          <div className="flex items-center justify-between gap-4">
+        {request.user && (
+          <div className="flex items-center justify-between gap-4 border-t pt-4">
             <div className="flex min-w-0 items-center gap-3">
-              <Avatar className="h-10 w-10">
+              <Avatar className="h-11 w-11">
                 <AvatarImage src={request.user.image ?? undefined} />
                 <AvatarFallback>
                   {(request.user.name?.[0] ?? request.user.email?.[0] ?? "?").toUpperCase()}
                 </AvatarFallback>
               </Avatar>
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">
+              <div className="min-w-0 space-y-1.5">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  Inviata da
+                </p>
+                <p className="truncate text-sm font-semibold">
                   {request.user.name ?? "Utente"}
                 </p>
                 {request.user.email && (
@@ -143,6 +172,10 @@ function AdminRequestDetailPage() {
                     {request.user.email}
                   </p>
                 )}
+                <p className="flex items-center gap-1.5 pt-1 text-xs text-muted-foreground">
+                  <Clock className="size-3 shrink-0" strokeWidth={1.5} />
+                  <span>Inviata {formatDateTime(request.created_at)}</span>
+                </p>
               </div>
             </div>
             {!isMaintainer && (
@@ -152,47 +185,100 @@ function AdminRequestDetailPage() {
                   params={{ userId: request.user.id }}
                 >
                   <UserCog className="size-4" />
-                  Apri scheda utente
+                  Scheda utente
                 </Link>
               </Button>
             )}
           </div>
-        </div>
-      )}
+        )}
 
-      {/* Submitted content preview */}
-      <div className="rounded-2xl border bg-card p-6 space-y-4">
-        <h3 className="text-sm font-semibold uppercase tracking-widest text-primary">
-          {isReport ? "Dettagli segnalazione" : isFileUpload ? "File caricato" : "Contenuto proposto"}
-        </h3>
-        <ContentPreview
-          submitted={request.submitted}
-          reportedQuestion={request.reported_question ?? null}
-        />
+        {request.admin_note && (
+          <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4">
+            <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+              Risposta inviata all&apos;utente
+            </p>
+            <p className="mt-1 text-sm">{request.admin_note}</p>
+          </div>
+        )}
       </div>
 
-      {/* Acknowledge section (reports + file uploads) */}
-      {isAcknowledgeOnly && isPending && (
-        <div className="rounded-2xl border bg-card p-6 space-y-4">
-          <h3 className="text-sm font-semibold uppercase tracking-widest text-primary">
-            Rispondi alla segnalazione
-          </h3>
-          <Textarea
-            value={reportNote}
-            onChange={(e) => setReportNote(e.target.value)}
-            placeholder="Lascia una nota per l'utente (opzionale)"
-            rows={3}
-            className="rounded-xl"
-          />
-          <Button
-            className="gap-1.5 rounded-xl"
-            onClick={() => acknowledge.mutate({ id: request.id, admin_note: reportNote })}
-            disabled={acknowledge.isPending}
-          >
-            <Eye className="size-4" />
-            {acknowledge.isPending ? "Salvataggio..." : "Presa visione"}
-          </Button>
+      {/* 2. The user's message — only when there is one */}
+      {hasUserMessage && (
+        <section className="space-y-3">
+          <SectionLabel>Messaggio dell&apos;utente</SectionLabel>
+          <div className="space-y-3 rounded-2xl border bg-card p-6">
+            {reasons.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {reasons.map((r) => (
+                  <Badge
+                    key={r}
+                    variant="outline"
+                    className="rounded-full border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400"
+                  >
+                    {REASON_LABELS[r] ?? r}
+                  </Badge>
+                ))}
+              </div>
+            )}
+            {userComment && (
+              <p className="text-sm leading-relaxed">{userComment}</p>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* 3. The material under review */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <SectionLabel>{materialLabel}</SectionLabel>
+          {reportedQuestionId && (
+            <Button asChild variant="outline" size="sm" className="gap-1.5 rounded-xl">
+              <Link
+                to="/admin/questions/$questionId"
+                params={{ questionId: reportedQuestionId }}
+              >
+                <Pencil className="size-3.5" />
+                Modifica domanda
+              </Link>
+            </Button>
+          )}
         </div>
+        <MaterialPreview
+          submitted={submitted}
+          reportedQuestion={request.reported_question ?? null}
+        />
+      </section>
+
+      {/* 4. Response area (reports + file uploads, while pending) */}
+      {isAcknowledgeOnly && isPending && (
+        <section className="space-y-3">
+          <SectionLabel>Rispondi e prendi in carico</SectionLabel>
+          <div className="space-y-4 rounded-2xl border bg-card p-6">
+            <PresetReplies
+              presets={ACK_PRESETS}
+              onPick={(text) =>
+                setReportNote((prev) => (prev ? `${prev} ${text}` : text))
+              }
+            />
+            <Textarea
+              value={reportNote}
+              onChange={(e) => setReportNote(e.target.value)}
+              placeholder="Lascia una nota per l'utente (opzionale)"
+              rows={3}
+              className="rounded-xl"
+            />
+            <div className="flex justify-end">
+              <Button
+                className="gap-1.5 rounded-xl"
+                onClick={() => acknowledge.mutate({ id: request.id, admin_note: reportNote })}
+                disabled={acknowledge.isPending}
+              >
+                <Eye className="size-4" />
+                {acknowledge.isPending ? "Salvataggio..." : "Presa visione"}
+              </Button>
+            </div>
+          </div>
+        </section>
       )}
 
       <HandleRequestDialog
@@ -204,14 +290,15 @@ function AdminRequestDetailPage() {
   )
 }
 
-// ─── Content Preview ───
-
-const REASON_LABELS: Record<string, string> = {
-  errata: "Errata",
-  imprecisa: "Imprecisa",
-  fuori_contesto: "Fuori contesto",
-  altro: "Altro",
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <h3 className="px-1 text-xs font-semibold uppercase tracking-widest text-primary">
+      {children}
+    </h3>
+  )
 }
+
+// ─── Material preview (the content under review, without the user's words) ───
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -219,7 +306,7 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function ContentPreview({
+function MaterialPreview({
   submitted,
   reportedQuestion,
 }: {
@@ -231,54 +318,21 @@ function ContentPreview({
   }
 
   if (submitted.type === "report") {
-    return (
-      <div className="space-y-4">
-        <div className="flex flex-wrap gap-1.5">
-          {submitted.reasons.map((r) => (
-            <Badge key={r} variant="outline" className="rounded-full border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400">
-              {REASON_LABELS[r] ?? r}
-            </Badge>
-          ))}
-        </div>
-        {submitted.comment && (
-          <div className="rounded-xl border p-4">
-            <p className="text-xs font-medium text-muted-foreground mb-1">Commento utente</p>
-            <p className="text-sm">{submitted.comment}</p>
-          </div>
-        )}
-
-        <div className="space-y-2">
-          <div className="flex items-center justify-between gap-2">
-            <p className="text-xs font-medium text-muted-foreground">Domanda segnalata</p>
-            <Button asChild variant="outline" size="sm" className="gap-1.5 rounded-xl">
-              <Link
-                to="/admin/questions/$questionId"
-                params={{ questionId: submitted.question_id }}
-              >
-                <Pencil className="size-3.5" />
-                Modifica domanda
-              </Link>
-            </Button>
-          </div>
-
-          {reportedQuestion ? (
-            <ReportedQuestionCard question={reportedQuestion} />
-          ) : (
-            <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 space-y-2">
-              <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
-                La domanda non è più disponibile (potrebbe essere stata eliminata o modificata). Contenuto al momento della segnalazione:
-              </p>
-              <MarkdownRenderer content={submitted.question_content} className="text-sm" />
-            </div>
-          )}
-        </div>
+    return reportedQuestion ? (
+      <ReportedQuestionCard question={reportedQuestion} />
+    ) : (
+      <div className="space-y-2 rounded-2xl border border-amber-500/30 bg-amber-500/5 p-6">
+        <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+          La domanda non è più disponibile (potrebbe essere stata eliminata o modificata). Contenuto al momento della segnalazione:
+        </p>
+        <MarkdownRenderer content={submitted.question_content} className="text-sm" />
       </div>
     )
   }
 
   if (submitted.type === "section") {
     return (
-      <div className="rounded-xl border p-5 space-y-2">
+      <div className="space-y-2 rounded-2xl border bg-card p-6">
         <p className="text-lg font-semibold">{submitted.name}</p>
         {submitted.description && (
           <p className="text-sm text-muted-foreground">{submitted.description}</p>
@@ -302,7 +356,7 @@ function QuestionCard({ question, index }: { question: SubmittedQuestion; index:
   const diffLabels = { EASY: "Facile", MEDIUM: "Medio", HARD: "Difficile" }
 
   return (
-    <div className="rounded-xl border p-4 space-y-3">
+    <div className="space-y-3 rounded-2xl border bg-card p-5">
       <div className="flex items-center justify-between">
         <p className="text-xs font-semibold text-muted-foreground">Domanda {index + 1}</p>
         <div className="flex gap-1.5">
@@ -379,7 +433,7 @@ function ReportedQuestionCard({ question }: { question: ReportedQuestion }) {
   const diffLabels = { EASY: "Facile", MEDIUM: "Medio", HARD: "Difficile" }
 
   return (
-    <div className="rounded-xl border p-4 space-y-3">
+    <div className="space-y-3 rounded-2xl border bg-card p-5">
       <div className="flex items-center justify-end gap-1.5">
         <Badge variant="outline" className="rounded-full text-[10px]">
           {typeLabels[question.question_type]}
@@ -466,32 +520,24 @@ function FileUploadPreview({ file }: { file: SubmittedFileUpload }) {
   }
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-4 rounded-xl border p-5">
-        <div className="rounded-xl bg-emerald-500/10 p-3">
-          <FileUp className="size-6 text-emerald-500" strokeWidth={1.5} />
-        </div>
-        <div className="flex-1">
-          <p className="font-medium">{file.file_name}</p>
-          <p className="text-sm text-muted-foreground">{formatFileSize(file.file_size)}</p>
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          className="gap-1.5 rounded-xl"
-          onClick={handleDownload}
-          disabled={downloading}
-        >
-          <Download className="size-4" />
-          {downloading ? "Download..." : "Scarica"}
-        </Button>
+    <div className="flex items-center gap-4 rounded-2xl border bg-card p-5">
+      <div className="rounded-xl bg-emerald-500/10 p-3">
+        <FileUp className="size-6 text-emerald-500" strokeWidth={1.5} />
       </div>
-      {file.comment && (
-        <div className="rounded-xl border p-4">
-          <p className="text-xs font-medium text-muted-foreground mb-1">Commento utente</p>
-          <p className="text-sm">{file.comment}</p>
-        </div>
-      )}
+      <div className="flex-1">
+        <p className="font-medium">{file.file_name}</p>
+        <p className="text-sm text-muted-foreground">{formatFileSize(file.file_size)}</p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1.5 rounded-xl"
+        onClick={handleDownload}
+        disabled={downloading}
+      >
+        <Download className="size-4" />
+        {downloading ? "Download..." : "Scarica"}
+      </Button>
     </div>
   )
 }

--- a/src/routes/_app/admin/requests/$requestId.tsx
+++ b/src/routes/_app/admin/requests/$requestId.tsx
@@ -2,9 +2,10 @@ import { useState } from "react"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { seoHead } from "@/lib/seo"
-import { ArrowLeft, CheckCircle2, ChevronDown, Download, Eye, FileUp, MapPin, Pencil, Settings2 } from "lucide-react"
+import { ArrowLeft, CheckCircle2, ChevronDown, Download, Eye, FileUp, MapPin, Pencil, Settings2, UserCog } from "lucide-react"
 
 import { AdminPageHeader } from "@/components/admin/admin-page-header"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
@@ -13,6 +14,7 @@ import { MarkdownRenderer } from "@/components/ui/markdown-renderer"
 import { RequestStatusBadge } from "@/components/requests/request-status-badge"
 import { RequestTypeBadge } from "@/components/requests/request-type-badge"
 import { Textarea } from "@/components/ui/textarea"
+import { useAuth } from "@/hooks/useAuth"
 import { requestQueries } from "@/lib/requests/queries"
 import { useAcknowledgeRequest, useApproveRequest } from "@/lib/requests/mutations"
 import { getFileDownloadUrlFn } from "@/lib/requests/server"
@@ -40,6 +42,8 @@ function AdminRequestDetailPage() {
   const [reportNote, setReportNote] = useState("")
   const approve = useApproveRequest()
   const acknowledge = useAcknowledgeRequest()
+  const { user: currentUser } = useAuth()
+  const isMaintainer = currentUser?.role === "MAINTAINER"
 
   const isPending = request.status === "PENDING"
   const isReport = request.request_type === "REPORT"
@@ -115,6 +119,46 @@ function AdminRequestDetailPage() {
           </div>
         )}
       </div>
+
+      {/* Author */}
+      {request.user && (
+        <div className="rounded-2xl border bg-card p-6">
+          <h3 className="mb-4 text-sm font-semibold uppercase tracking-widest text-primary">
+            Inviata da
+          </h3>
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex min-w-0 items-center gap-3">
+              <Avatar className="h-10 w-10">
+                <AvatarImage src={request.user.image ?? undefined} />
+                <AvatarFallback>
+                  {(request.user.name?.[0] ?? request.user.email?.[0] ?? "?").toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">
+                  {request.user.name ?? "Utente"}
+                </p>
+                {request.user.email && (
+                  <p className="truncate text-xs text-muted-foreground">
+                    {request.user.email}
+                  </p>
+                )}
+              </div>
+            </div>
+            {!isMaintainer && (
+              <Button asChild variant="outline" size="sm" className="shrink-0 gap-1.5 rounded-xl">
+                <Link
+                  to="/admin/users/$userId"
+                  params={{ userId: request.user.id }}
+                >
+                  <UserCog className="size-4" />
+                  Apri scheda utente
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Submitted content preview */}
       <div className="rounded-2xl border bg-card p-6 space-y-4">

--- a/src/routes/_app/admin/requests/index.tsx
+++ b/src/routes/_app/admin/requests/index.tsx
@@ -23,7 +23,6 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { RequestStatusBadge } from "@/components/requests/request-status-badge"
-import { RequestTypeBadge } from "@/components/requests/request-type-badge"
 import { requestQueries } from "@/lib/requests/queries"
 
 import type {
@@ -60,7 +59,7 @@ function AdminRequestsPage() {
   const { data: requests } = useSuspenseQuery(requestQueries.adminRequests())
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(1)
-  const [tab, setTab] = useState<TypeTab>("proposals")
+  const [tab, setTab] = useState<TypeTab>("reports")
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("open")
   const { sort, toggleSort } = useSort<AdminContentRequest>()
 
@@ -75,6 +74,8 @@ function AdminRequestsPage() {
     if (statusFilter === "handled") return !isOpen(r)
     return true
   })
+  // "Gestita da" only carries meaning once requests are handled.
+  const showHandledBy = statusFilter === "handled"
 
   const { paged, totalPages, safePage, totalItems } = usePaginatedSearch(
     filtered,
@@ -89,7 +90,7 @@ function AdminRequestsPage() {
   )
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 py-2">
       <AdminPageHeader
         title="Richieste Contenuto"
         description="Gestisci le richieste degli utenti per nuovi contenuti e segnalazioni."
@@ -104,18 +105,18 @@ function AdminRequestsPage() {
       >
         <TabsList className="rounded-2xl bg-muted/50 p-1">
           <TabsTrigger
-            value="proposals"
-            className="gap-1.5 rounded-xl data-[state=active]:bg-background data-[state=active]:shadow-sm"
-          >
-            Contenuti proposti
-            {openProposals > 0 && <TabCount value={openProposals} />}
-          </TabsTrigger>
-          <TabsTrigger
             value="reports"
             className="gap-1.5 rounded-xl data-[state=active]:bg-background data-[state=active]:shadow-sm"
           >
             Segnalazioni
             {openReports > 0 && <TabCount value={openReports} />}
+          </TabsTrigger>
+          <TabsTrigger
+            value="proposals"
+            className="gap-1.5 rounded-xl data-[state=active]:bg-background data-[state=active]:shadow-sm"
+          >
+            Contenuti proposti
+            {openProposals > 0 && <TabCount value={openProposals} />}
           </TabsTrigger>
         </TabsList>
       </Tabs>
@@ -171,11 +172,11 @@ function AdminRequestsPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead className="pl-6">Utente</TableHead>
-                  <TableHead>Tipo</TableHead>
                   <TableHead>Stato</TableHead>
                   <TableHead>
                     <SortableHeader label="Data" sortKey="created_at" sort={sort} onSort={toggleSort} />
                   </TableHead>
+                  {showHandledBy && <TableHead>Gestita da</TableHead>}
                   <TableHead />
                 </TableRow>
               </TableHeader>
@@ -200,14 +201,26 @@ function AdminRequestsPage() {
                       </Link>
                     </TableCell>
                     <TableCell>
-                      <RequestTypeBadge type={request.request_type} />
-                    </TableCell>
-                    <TableCell>
                       <RequestStatusBadge status={request.status} />
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">
                       {new Date(request.created_at).toLocaleDateString("it-IT")}
                     </TableCell>
+                    {showHandledBy && (
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Avatar className="h-6 w-6">
+                            <AvatarImage src={request.handledBy?.image ?? undefined} />
+                            <AvatarFallback className="text-[9px]">
+                              {(request.handledBy?.name?.[0] ?? "T").toUpperCase()}
+                            </AvatarFallback>
+                          </Avatar>
+                          <span className="text-sm text-muted-foreground">
+                            {request.handledBy?.name ?? "Team"}
+                          </span>
+                        </div>
+                      </TableCell>
+                    )}
                     <TableCell className="pr-6">
                       <ArrowRight className="h-4 w-4 text-muted-foreground/50 transition-transform group-hover:translate-x-1 group-hover:text-primary" />
                     </TableCell>

--- a/src/routes/_app/admin/requests/index.tsx
+++ b/src/routes/_app/admin/requests/index.tsx
@@ -74,8 +74,6 @@ function AdminRequestsPage() {
     if (statusFilter === "handled") return !isOpen(r)
     return true
   })
-  // "Gestita da" only carries meaning once requests are handled.
-  const showHandledBy = statusFilter === "handled"
 
   const { paged, totalPages, safePage, totalItems } = usePaginatedSearch(
     filtered,
@@ -176,7 +174,7 @@ function AdminRequestsPage() {
                   <TableHead>
                     <SortableHeader label="Data" sortKey="created_at" sort={sort} onSort={toggleSort} />
                   </TableHead>
-                  {showHandledBy && <TableHead>Gestita da</TableHead>}
+                  <TableHead>Gestita da</TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
@@ -206,8 +204,8 @@ function AdminRequestsPage() {
                     <TableCell className="text-sm text-muted-foreground">
                       {new Date(request.created_at).toLocaleDateString("it-IT")}
                     </TableCell>
-                    {showHandledBy && (
-                      <TableCell>
+                    <TableCell>
+                      {request.handled_at ? (
                         <div className="flex items-center gap-2">
                           <Avatar className="h-6 w-6">
                             <AvatarImage src={request.handledBy?.image ?? undefined} />
@@ -219,8 +217,10 @@ function AdminRequestsPage() {
                             {request.handledBy?.name ?? "Team"}
                           </span>
                         </div>
-                      </TableCell>
-                    )}
+                      ) : (
+                        <span className="text-sm text-muted-foreground/50">—</span>
+                      )}
+                    </TableCell>
                     <TableCell className="pr-6">
                       <ArrowRight className="h-4 w-4 text-muted-foreground/50 transition-transform group-hover:translate-x-1 group-hover:text-primary" />
                     </TableCell>

--- a/src/routes/_app/admin/requests/index.tsx
+++ b/src/routes/_app/admin/requests/index.tsx
@@ -13,6 +13,7 @@ import { AdminSearch } from "@/components/admin/admin-search"
 import { SortableHeader, useSort } from "@/components/admin/sortable-header"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { EmptyState } from "@/components/ui/empty-state"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   Table,
   TableBody,
@@ -25,7 +26,20 @@ import { RequestStatusBadge } from "@/components/requests/request-status-badge"
 import { RequestTypeBadge } from "@/components/requests/request-type-badge"
 import { requestQueries } from "@/lib/requests/queries"
 
-import type { AdminContentRequest, SubmittedContent } from "@/lib/requests/types"
+import type {
+  AdminContentRequest,
+  ContentRequestStatus,
+  SubmittedContent,
+} from "@/lib/requests/types"
+
+// Open requests still await action; the rest are considered handled (approved,
+// acknowledged or rejected) and are hidden from the default view.
+const OPEN_STATUSES: ContentRequestStatus[] = ["PENDING", "NEEDS_REVISION"]
+const isOpen = (r: AdminContentRequest) => OPEN_STATUSES.includes(r.status)
+const isReport = (r: AdminContentRequest) => r.request_type === "REPORT"
+
+type TypeTab = "proposals" | "reports"
+type StatusFilter = "open" | "handled" | "all"
 
 function generateTitle(submitted: SubmittedContent): string {
   if (submitted.type === "section") return `Nuova sezione: ${submitted.name}`
@@ -46,12 +60,21 @@ function AdminRequestsPage() {
   const { data: requests } = useSuspenseQuery(requestQueries.adminRequests())
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(1)
-  const [statusFilter, setStatusFilter] = useState<string>("all")
+  const [tab, setTab] = useState<TypeTab>("proposals")
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("open")
   const { sort, toggleSort } = useSort<AdminContentRequest>()
 
-  const filtered = statusFilter === "all"
-    ? requests
-    : requests.filter((r) => r.status === statusFilter)
+  const openProposals = requests.filter((r) => !isReport(r) && isOpen(r)).length
+  const openReports = requests.filter((r) => isReport(r) && isOpen(r)).length
+
+  const byTab = requests.filter((r) =>
+    tab === "reports" ? isReport(r) : !isReport(r),
+  )
+  const filtered = byTab.filter((r) => {
+    if (statusFilter === "open") return isOpen(r)
+    if (statusFilter === "handled") return !isOpen(r)
+    return true
+  })
 
   const { paged, totalPages, safePage, totalItems } = usePaginatedSearch(
     filtered,
@@ -72,19 +95,45 @@ function AdminRequestsPage() {
         description="Gestisci le richieste degli utenti per nuovi contenuti e segnalazioni."
       />
 
-      {/* Filters + Search */}
+      <Tabs
+        value={tab}
+        onValueChange={(v) => {
+          setTab(v as TypeTab)
+          setPage(1)
+        }}
+      >
+        <TabsList className="rounded-2xl bg-muted/50 p-1">
+          <TabsTrigger
+            value="proposals"
+            className="gap-1.5 rounded-xl data-[state=active]:bg-background data-[state=active]:shadow-sm"
+          >
+            Contenuti proposti
+            {openProposals > 0 && <TabCount value={openProposals} />}
+          </TabsTrigger>
+          <TabsTrigger
+            value="reports"
+            className="gap-1.5 rounded-xl data-[state=active]:bg-background data-[state=active]:shadow-sm"
+          >
+            Segnalazioni
+            {openReports > 0 && <TabCount value={openReports} />}
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {/* Status filter + Search */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-wrap gap-1.5">
           {[
+            { value: "open", label: "Da gestire" },
+            { value: "handled", label: "Gestite" },
             { value: "all", label: "Tutte" },
-            { value: "PENDING", label: "In attesa" },
-            { value: "NEEDS_REVISION", label: "Da revisionare" },
-            { value: "APPROVED", label: "Approvate" },
-            { value: "REJECTED", label: "Rifiutate" },
           ].map((f) => (
             <button
               key={f.value}
-              onClick={() => { setStatusFilter(f.value); setPage(1) }}
+              onClick={() => {
+                setStatusFilter(f.value as StatusFilter)
+                setPage(1)
+              }}
               className={`rounded-xl px-3 py-1.5 text-xs font-medium transition-colors ${
                 statusFilter === f.value
                   ? "bg-primary text-primary-foreground"
@@ -99,11 +148,15 @@ function AdminRequestsPage() {
       </div>
 
       {/* Table */}
-      {requests.length === 0 ? (
+      {filtered.length === 0 ? (
         <EmptyState
           icon={Inbox}
-          title="Nessuna richiesta"
-          description="Non ci sono richieste di contenuto da gestire."
+          title={statusFilter === "open" ? "Nessuna richiesta da gestire" : "Nessuna richiesta"}
+          description={
+            tab === "reports"
+              ? "Non ci sono segnalazioni in questa vista."
+              : "Non ci sono contenuti proposti in questa vista."
+          }
         />
       ) : paged.length === 0 ? (
         <EmptyState
@@ -174,5 +227,13 @@ function AdminRequestsPage() {
         </>
       )}
     </div>
+  )
+}
+
+function TabCount({ value }: { value: number }) {
+  return (
+    <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-bold text-primary-foreground">
+      {value}
+    </span>
   )
 }

--- a/src/routes/_app/admin/route.tsx
+++ b/src/routes/_app/admin/route.tsx
@@ -21,7 +21,7 @@ function AdminLayout() {
 
       <div className="container flex gap-6 py-6">
       <aside className="hidden w-72 shrink-0 lg:block">
-        <div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto">
+        <div className="sticky top-6 max-h-[calc(100vh-3rem)] overflow-y-auto">
           <AdminSidebar />
         </div>
       </aside>

--- a/src/routes/_app/browse/$department/$course/$class/$section/index.tsx
+++ b/src/routes/_app/browse/$department/$course/$class/$section/index.tsx
@@ -135,6 +135,7 @@ function SectionPage() {
           <BrowseAdminButton
             to="/admin/sections/$sectionId"
             params={{ sectionId: section.id }}
+            courseId={section.class.course.id}
           />
         }
       />

--- a/src/routes/_app/browse/$department/$course/$class/index.tsx
+++ b/src/routes/_app/browse/$department/$course/$class/index.tsx
@@ -236,6 +236,7 @@ function ClassPage() {
             <BrowseAdminButton
               to="/admin/classes/$classId"
               params={{ classId: classData.id }}
+              courseId={classData.course.id}
             />
             {isAuthenticated && (
               <>

--- a/src/routes/_app/browse/$department/$course/index.tsx
+++ b/src/routes/_app/browse/$department/$course/index.tsx
@@ -262,6 +262,7 @@ function CoursePage() {
           <BrowseAdminButton
             to="/admin/courses/$courseId"
             params={{ courseId: course.id }}
+            courseId={course.id}
           />
         }
       />

--- a/src/routes/_app/user/requests/index.tsx
+++ b/src/routes/_app/user/requests/index.tsx
@@ -21,6 +21,8 @@ import {
 import { UserRequestsSkeleton } from "@/components/skeletons"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { ConfirmationDialog } from "@/components/ui/confirmation-dialog"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -36,7 +38,11 @@ import { RequestStatusBadge } from "@/components/requests/request-status-badge"
 import { UserBreadcrumb } from "@/components/user/user-breadcrumb"
 import { UserHero } from "@/components/user/user-hero"
 import { requestQueries } from "@/lib/requests/queries"
-import { useReviseRequest } from "@/lib/requests/mutations"
+import {
+  useDeleteReport,
+  useReviseRequest,
+  useUpdateReport,
+} from "@/lib/requests/mutations"
 import { useReducedMotion } from "@/hooks/useReducedMotion"
 import { staggerContainer, staggerItem, withReducedMotion } from "@/lib/motion"
 import { cn } from "@/lib/utils"
@@ -62,6 +68,13 @@ const REASON_LABELS: Record<string, string> = {
   fuori_contesto: "Fuori contesto",
   altro: "Altro",
 }
+
+const REPORT_REASON_OPTIONS = [
+  { id: "errata", label: "Errata", description: "La domanda o la risposta contiene un errore" },
+  { id: "imprecisa", label: "Imprecisa", description: "La formulazione è ambigua o poco chiara" },
+  { id: "fuori_contesto", label: "Fuori contesto", description: "La domanda non appartiene a questa sezione" },
+  { id: "altro", label: "Altro", description: "Specifica nel commento" },
+] as const
 
 function generateTitle(submitted: SubmittedContent): string {
   if (submitted.type === "section") return `Nuova sezione: ${submitted.name}`
@@ -242,6 +255,9 @@ function ContributionRow({
               {/* Editable form or read-only preview */}
               {request.status === "NEEDS_REVISION" ? (
                 <RevisionForm requestId={request.id} submitted={request.submitted} />
+              ) : request.status === "PENDING" &&
+                request.submitted.type === "report" ? (
+                <ReportEditor requestId={request.id} report={request.submitted} />
               ) : (
                 <SubmittedContentPreview submitted={request.submitted} />
               )}
@@ -576,6 +592,135 @@ function RevisionQuestionEditor({
 }
 
 // ─── Previews ───
+
+// ─── Report: edit + delete while pending ───
+
+function ReportEditor({ requestId, report }: { requestId: string; report: SubmittedReport }) {
+  const [editing, setEditing] = useState(false)
+  const [reasons, setReasons] = useState<string[]>(report.reasons)
+  const [comment, setComment] = useState(report.comment ?? "")
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const update = useUpdateReport(() => setEditing(false))
+  const del = useDeleteReport()
+
+  const hasAltro = reasons.includes("altro")
+  const canSave = reasons.length > 0 && (!hasAltro || comment.trim().length > 0)
+
+  function toggleReason(id: string) {
+    setReasons((prev) =>
+      prev.includes(id) ? prev.filter((r) => r !== id) : [...prev, id],
+    )
+  }
+
+  if (!editing) {
+    return (
+      <div className="space-y-3">
+        <ReportPreview report={report} />
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            className="gap-1.5 rounded-xl"
+            onClick={() => setEditing(true)}
+          >
+            <Pencil className="size-3.5" />
+            Modifica
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="gap-1.5 rounded-xl text-destructive hover:text-destructive"
+            onClick={() => setConfirmDelete(true)}
+          >
+            <Trash2 className="size-3.5" />
+            Elimina
+          </Button>
+        </div>
+        <ConfirmationDialog
+          open={confirmDelete}
+          onOpenChange={setConfirmDelete}
+          title="Elimina segnalazione"
+          description="Sei sicuro di voler eliminare questa segnalazione? L'operazione è irreversibile."
+          confirmText="Elimina"
+          variant="destructive"
+          onConfirm={() => del.mutate({ id: requestId })}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-primary/20 bg-primary/5 p-5">
+      <p className="text-xs font-semibold text-primary">Modifica la segnalazione</p>
+
+      <div className="space-y-2">
+        {REPORT_REASON_OPTIONS.map((reason) => {
+          const checked = reasons.includes(reason.id)
+          return (
+            <label
+              key={reason.id}
+              className={cn(
+                "flex cursor-pointer items-start gap-3 rounded-xl border-2 p-3 transition-all",
+                checked
+                  ? "border-primary/30 bg-primary/5"
+                  : "border-transparent bg-muted/50 hover:bg-accent/50",
+              )}
+            >
+              <Checkbox
+                checked={checked}
+                onCheckedChange={() => toggleReason(reason.id)}
+                className="mt-0.5"
+              />
+              <div>
+                <p className="text-sm font-medium">{reason.label}</p>
+                <p className="text-xs text-muted-foreground">{reason.description}</p>
+              </div>
+            </label>
+          )
+        })}
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-sm font-medium">
+          Commento {hasAltro ? "(obbligatorio)" : "(opzionale)"}
+        </label>
+        <Textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="Descrivi il problema..."
+          rows={3}
+          className={cn("rounded-xl", hasAltro && !comment.trim() && "border-red-500/50")}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="rounded-xl"
+          onClick={() => {
+            setReasons(report.reasons)
+            setComment(report.comment ?? "")
+            setEditing(false)
+          }}
+        >
+          Annulla
+        </Button>
+        <Button
+          size="sm"
+          className="gap-1.5 rounded-xl"
+          onClick={() =>
+            update.mutate({ id: requestId, reasons, comment: comment.trim() || null })
+          }
+          disabled={!canSave || update.isPending}
+        >
+          <Send className="size-3.5" />
+          {update.isPending ? "Salvataggio..." : "Salva modifiche"}
+        </Button>
+      </div>
+    </div>
+  )
+}
 
 function ReportPreview({ report }: { report: SubmittedReport }) {
   return (


### PR DESCRIPTION
## Maintainer access control
- Gate every admin detail page (department / course / class / section / question) and the public "Gestisci" button by maintainer scope — out-of-scope maintainers are redirected to the dashboard; departments are off-limits.
- Scope content requests to maintainers across list, sidebar count, detail and handle/approve/acknowledge mutations.

## Content requests — UX
- Rework the list: **Segnalazioni** / **Contenuti proposti** tabs (reports first), default **"Da gestire"** view, and a **"Gestita da"** column.
- Redesign the request detail with a clear hierarchy (target in the subtitle, author + send date together, outcome with the status), compact dates, and quick preset replies.
- Track and surface **who handled** each request (`handled_by`) in list and detail; the user-facing notification stays generic.
- Let users **edit and delete their own pending reports** (read-only once accepted); also fixes proposal *revise*, which previously failed silently under admin-only RLS.

## Admin UI
- Role-themed **badge** in the admin sidebar (Super Admin / Admin / Maintainer).
- Keep the admin sidebar at a consistent vertical position.
